### PR TITLE
v0.4.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,31 @@
 History
 =======
 
+0.4.0 (2021-08-09)
+------------------
+**Features and Improvements**
+
+* Add support for serializing the following Python types:
+    - ``defaultdict`` (via the ``typing.DefaultDict`` annotation)
+    - ``UUID``'s
+    - The special variadic form of ``Tuple``.
+      For example, ``Tuple[str, ...]``.
+    - A special case where optional type arguments are passed to ``Tuple``.
+      For example, ``Tuple[str, Optional[int], Union[bool, str, None]]``
+* Add new ``LetterCase.LISP`` Enum member, which references the ``to_lisp_case`` helper function
+* All the ``Enum``-subclass attributes in ``JSONSerializable.Meta``
+  now additionally support strings as values; they will be parsed using the Enum
+  ``name`` field by default, and should format helpful messages on
+  any lookup errors.
+* Remove the ``LoadMixin.load_with_object`` method, as that was already
+  deprecated and slated to be removed.
+
+**Bugfixes**
+
+* Update the ``get_class_name`` helper function to handle the edge case
+  when classes are defined within a function.
+* Update a few ``load_to...`` methods as a ``staticmethod``
+
 0.3.0 (2021-08-05)
 ------------------
 * Some minor code refactoring

--- a/dataclass_wizard/__version__.py
+++ b/dataclass_wizard/__version__.py
@@ -6,7 +6,7 @@ __title__ = 'dataclass-wizard'
 __description__ = 'Marshal dataclasses to/from JSON and Python dict objects, ' \
                   'and add support for field properties with initial values.'
 __url__ = 'https://github.com/rnag/dataclass-wizard'
-__version__ = '0.3.0'
+__version__ = '0.4.0'
 __author__ = 'Ritvik Nag'
 __author_email__ = 'rv.kvetch@gmail.com'
 __license__ = 'Apache 2.0'

--- a/dataclass_wizard/abstractions.py
+++ b/dataclass_wizard/abstractions.py
@@ -7,11 +7,10 @@ from datetime import datetime, time, date
 from decimal import Decimal
 from typing import (
     Any, Type, Union, List, Tuple, NamedTupleMeta, Dict, SupportsFloat,
-    Optional, SupportsInt, FrozenSet, Sequence, AnyStr, TypeVar, Text
+    Optional, SupportsInt, FrozenSet, Sequence, AnyStr, TypeVar, Text, Callable
 )
 
-from .type_def import M, N, T, E, U
-
+from .type_def import M, N, T, E, U, DD
 
 # Create a generic variable that can be 'AbstractJSONWizard', or any subclass.
 W = TypeVar('W', bound='AbstractJSONWizard')
@@ -186,10 +185,10 @@ class AbstractLoader(ABC):
         sub-class of the :class:`UUID` type)
         """
 
-    @classmethod
+    @staticmethod
     @abstractmethod
     def load_to_list(
-            cls, o: Union[List, Tuple], base_type: Type[List],
+            o: Union[List, Tuple], base_type: Type[List],
             elem_parser: AbstractParser) -> List[Any]:
         """
         Load a list or tuple into a new object of type `base_type` (generally
@@ -217,10 +216,10 @@ class AbstractLoader(ABC):
         un-annotated `namedtuple`)
         """
 
-    @classmethod
+    @staticmethod
     @abstractmethod
     def load_to_dict(
-            cls, o: Dict, base_type: Type[M],
+            o: Dict, base_type: Type[M],
             key_parser: AbstractParser,
             val_parser: AbstractParser) -> Dict:
         """
@@ -228,10 +227,22 @@ class AbstractLoader(ABC):
         :class:`dict` or a sub-class of one)
         """
 
-    @classmethod
+    @staticmethod
+    @abstractmethod
+    def load_to_defaultdict(
+            o: Dict, base_type: Type[DD],
+            default_factory: Callable[[], T],
+            key_parser: AbstractParser,
+            val_parser: AbstractParser) -> DD:
+        """
+        Load an object `o` into a new object of type `base_type` (generally a
+        :class:`collections.defaultdict` or a sub-class of one)
+        """
+
+    @staticmethod
     @abstractmethod
     def load_to_typed_dict(
-            cls, o: Dict, base_type: Type[M],
+            o: Dict, base_type: Type[M],
             key_to_parser: Dict[str, AbstractParser],
             required_keys: FrozenSet[str],
             optional_keys: FrozenSet[str]) -> Dict:

--- a/dataclass_wizard/abstractions.py
+++ b/dataclass_wizard/abstractions.py
@@ -5,13 +5,12 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, InitVar
 from datetime import datetime, time, date
 from decimal import Decimal
-from enum import Enum
 from typing import (
     Any, Type, Union, List, Tuple, NamedTupleMeta, Dict, SupportsFloat,
     Optional, SupportsInt, FrozenSet, Sequence, AnyStr, TypeVar, Text
 )
 
-from .type_def import M, N, T
+from .type_def import M, N, T, E, U
 
 
 # Create a generic variable that can be 'AbstractJSONWizard', or any subclass.
@@ -173,10 +172,18 @@ class AbstractLoader(ABC):
 
     @staticmethod
     @abstractmethod
-    def load_to_enum(o: Union[AnyStr, N], base_type: Type[Enum]) -> Enum:
+    def load_to_enum(o: Union[AnyStr, N], base_type: Type[E]) -> E:
         """
         Load an object `o` into a new object of type `base_type` (generally a
         sub-class of the :class:`Enum` type)
+        """
+
+    @staticmethod
+    @abstractmethod
+    def load_to_uuid(o: Union[AnyStr, U], base_type: Type[U]) -> U:
+        """
+        Load an object `o` into a new object of type `base_type` (generally a
+        sub-class of the :class:`UUID` type)
         """
 
     @classmethod

--- a/dataclass_wizard/abstractions.py
+++ b/dataclass_wizard/abstractions.py
@@ -269,13 +269,6 @@ class AbstractLoader(ABC):
 
     @classmethod
     @abstractmethod
-    def load_with_object(cls, o: Any, ann_type: Type[T]) -> T:
-        """
-        TODO consider removing this method
-        """
-
-    @classmethod
-    @abstractmethod
     def get_parser_for_annotation(cls, ann_type: Type[T],
                                   base_cls: Type[T] = None) -> AbstractParser:
         """

--- a/dataclass_wizard/class_helper.py
+++ b/dataclass_wizard/class_helper.py
@@ -109,12 +109,18 @@ def get_outer_class_name(inner_cls, default=None, raise_=True):
 
     """
     try:
-        return get_class_name(inner_cls).rsplit('.', 1)[-2]
+        name = get_class_name(inner_cls).rsplit('.', 1)[-2]
+        # This is mainly for our test cases, where we nest the class
+        # definition in the test func. Either way, it's not a valid class.
+        assert not name.endswith('<locals>')
 
-    except IndexError:
+    except (IndexError, AssertionError):
         if raise_:
             raise
         return default
+
+    else:
+        return name
 
 
 def get_class(obj):

--- a/dataclass_wizard/dumpers.py
+++ b/dataclass_wizard/dumpers.py
@@ -1,4 +1,5 @@
 # noinspection PyProtectedMember
+from collections import defaultdict
 from dataclasses import _is_dataclass_instance
 from datetime import datetime, time, date
 from decimal import Decimal
@@ -12,7 +13,7 @@ from .class_helper import (
     dataclass_fields, get_class, dataclass_field_to_json_field)
 from .constants import _DUMP_HOOKS
 from .log import LOG
-from .type_def import NoneType
+from .type_def import NoneType, DD
 from .utils.string_conv import to_camel_case
 
 
@@ -86,6 +87,14 @@ class DumpMixin(AbstractDumper, BaseDumpHook):
                    for k, v in o.items())
 
     @staticmethod
+    def dump_with_defaultdict(
+            o: Dict, _typ: Type[DD], dict_factory, hooks):
+
+        return {_asdict_inner(k, dict_factory, hooks):
+                _asdict_inner(v, dict_factory, hooks)
+                for k, v in o.items()}
+
+    @staticmethod
     def dump_with_decimal(o: Decimal, *_):
         return str(o)
 
@@ -123,6 +132,7 @@ def setup_default_dumper(cls=DumpMixin):
     cls.register_dump_hook(list, cls.dump_with_list_or_tuple)
     cls.register_dump_hook(tuple, cls.dump_with_list_or_tuple)
     cls.register_dump_hook(NamedTupleMeta, cls.dump_with_named_tuple)
+    cls.register_dump_hook(defaultdict, cls.dump_with_defaultdict)
     cls.register_dump_hook(dict, cls.dump_with_dict)
     cls.register_dump_hook(Decimal, cls.dump_with_decimal)
     # Dates and times

--- a/dataclass_wizard/dumpers.py
+++ b/dataclass_wizard/dumpers.py
@@ -4,6 +4,7 @@ from datetime import datetime, time, date
 from decimal import Decimal
 from enum import Enum
 from typing import Type, Dict, Any, List, Union, Tuple, NamedTupleMeta
+from uuid import UUID
 
 from .abstractions import AbstractDumper
 from .bases import BaseDumpHook
@@ -57,6 +58,10 @@ class DumpMixin(AbstractDumper, BaseDumpHook):
     @staticmethod
     def dump_with_enum(o: Enum, *_):
         return o.value
+
+    @staticmethod
+    def dump_with_uuid(o: UUID, *_):
+        return o.hex
 
     @staticmethod
     def dump_with_list_or_tuple(
@@ -114,6 +119,7 @@ def setup_default_dumper(cls=DumpMixin):
     cls.register_dump_hook(NoneType, cls.dump_with_null)
     # Complex types
     cls.register_dump_hook(Enum, cls.dump_with_enum)
+    cls.register_dump_hook(UUID, cls.dump_with_uuid)
     cls.register_dump_hook(list, cls.dump_with_list_or_tuple)
     cls.register_dump_hook(tuple, cls.dump_with_list_or_tuple)
     cls.register_dump_hook(NamedTupleMeta, cls.dump_with_named_tuple)

--- a/dataclass_wizard/enums.py
+++ b/dataclass_wizard/enums.py
@@ -5,6 +5,7 @@ Re-usable Enum definitions
 from enum import Enum
 
 from .utils.string_conv import *
+from .utils.wrappers import FuncWrapper
 
 
 class DateTimeTo(Enum):
@@ -13,12 +14,19 @@ class DateTimeTo(Enum):
 
 
 class LetterCase(Enum):
+
     # Converts strings (generally in snake case) to camel case.
     #   ex: `my_field_name` -> `myFieldName`
-    CAMEL = to_camel_case
+    CAMEL = FuncWrapper(to_camel_case)
     # Converts strings to "upper" camel case.
     #   ex: `my_field_name` -> `MyFieldName`
-    PASCAL = to_pascal_case
+    PASCAL = FuncWrapper(to_pascal_case)
+    # Converts strings (generally in camel or snake case) to lisp case.
+    #   ex: `myFieldName` -> `my-field-name`
+    LISP = FuncWrapper(to_lisp_case)
     # Converts strings (generally in camel case) to snake case.
     #   ex: `myFieldName` -> `my_field_name`
-    SNAKE = to_snake_case
+    SNAKE = FuncWrapper(to_snake_case)
+
+    def __call__(self, *args):
+        return self.value.f(*args)

--- a/dataclass_wizard/loaders.py
+++ b/dataclass_wizard/loaders.py
@@ -17,8 +17,10 @@ from .log import LOG
 from .parsers import *
 from .type_def import ExplicitNull, PyForwardRef, NoneType, M, N, T
 from .utils.string_conv import to_snake_case
-from .utils.type_check import is_literal, is_typed_dict, is_generic, get_origin, get_args
-from .utils.type_conv import as_bool, as_str, as_datetime, as_date, as_time, as_int
+from .utils.type_check import (
+    is_literal, is_typed_dict, is_generic, get_origin, get_args)
+from .utils.type_conv import (
+    as_bool, as_str, as_datetime, as_date, as_time, as_int)
 
 
 class LoadMixin(AbstractLoader, BaseLoadHook):

--- a/dataclass_wizard/loaders.py
+++ b/dataclass_wizard/loaders.py
@@ -6,6 +6,7 @@ from typing import (
     Dict, List, Tuple, Sequence, Optional, Union, Type, Any, NamedTupleMeta,
     SupportsFloat, SupportsInt, FrozenSet, AnyStr, Text
 )
+from uuid import UUID
 
 from .abstractions import AbstractLoader, AbstractParser
 from .bases import BaseLoadHook
@@ -15,7 +16,7 @@ from .constants import _LOAD_HOOKS
 from .errors import ParseError
 from .log import LOG
 from .parsers import *
-from .type_def import ExplicitNull, PyForwardRef, NoneType, M, N, T
+from .type_def import ExplicitNull, PyForwardRef, NoneType, M, N, T, E, U
 from .utils.string_conv import to_snake_case
 from .utils.type_check import (
     is_literal, is_typed_dict, is_generic, get_origin, get_args)
@@ -79,7 +80,12 @@ class LoadMixin(AbstractLoader, BaseLoadHook):
         return as_bool(o)
 
     @staticmethod
-    def load_to_enum(o: Union[AnyStr, N], base_type: Type[Enum]) -> Enum:
+    def load_to_enum(o: Union[AnyStr, N], base_type: Type[E]) -> E:
+
+        return base_type(o)
+
+    @staticmethod
+    def load_to_uuid(o: Union[AnyStr, U], base_type: Type[U]) -> U:
 
         return base_type(o)
 
@@ -214,6 +220,9 @@ class LoadMixin(AbstractLoader, BaseLoadHook):
                     elif issubclass(base_type, Enum):
                         load_hook = hooks.get(Enum)
 
+                    elif issubclass(base_type, UUID):
+                        load_hook = hooks.get(UUID)
+
                     elif issubclass(base_type, tuple) \
                             and hasattr(base_type, '_fields'):
                         load_hook = hooks.get(NamedTupleMeta)
@@ -327,6 +336,7 @@ def setup_default_loader(cls=LoadMixin):
     cls.register_load_hook(NoneType, cls.default_load_to)
     # Complex types
     cls.register_load_hook(Enum, cls.load_to_enum)
+    cls.register_load_hook(UUID, cls.load_to_uuid)
     cls.register_load_hook(list, cls.load_to_list)
     cls.register_load_hook(tuple, cls.load_to_tuple)
     cls.register_load_hook(NamedTupleMeta, cls.load_to_named_tuple)

--- a/dataclass_wizard/parsers.py
+++ b/dataclass_wizard/parsers.py
@@ -92,6 +92,7 @@ class OptionalParser(AbstractParser):
         self.parser = get_parser(self.base_type, cls)
 
     def __contains__(self, item):
+        """Check if parser is expected to handle the specified item type."""
         if type(item) is NoneType:
             return True
 
@@ -117,6 +118,7 @@ class UnionParser(AbstractParser):
                              if t is not NoneType)
 
     def __contains__(self, item):
+        """Check if parser is expected to handle the specified item type."""
         return type(item) in self.base_type
 
     def __call__(self, o: Any):

--- a/dataclass_wizard/type_def.py
+++ b/dataclass_wizard/type_def.py
@@ -8,6 +8,7 @@ __all__ = [
     'NUMBERS',
     'T',
     'E',
+    'U',
     'M',
     'N',
     'S'
@@ -15,6 +16,7 @@ __all__ = [
 
 from enum import Enum
 from typing import TypeVar, Mapping, Sequence
+from uuid import UUID
 
 from .constants import PY36, PY38_OR_ABOVE
 from .decorators import discard_kwargs
@@ -29,6 +31,9 @@ T = TypeVar('T')
 
 # Enum subclass type
 E = TypeVar('E', bound=Enum)
+
+# UUID subclass type
+U = TypeVar('U', bound=UUID)
 
 # Mapping type
 M = TypeVar('M', bound=Mapping)

--- a/dataclass_wizard/type_def.py
+++ b/dataclass_wizard/type_def.py
@@ -10,12 +10,13 @@ __all__ = [
     'E',
     'U',
     'M',
+    'DD',
     'N',
     'S'
 ]
 
 from enum import Enum
-from typing import TypeVar, Mapping, Sequence
+from typing import TypeVar, Mapping, Sequence, DefaultDict
 from uuid import UUID
 
 from .constants import PY36, PY38_OR_ABOVE
@@ -37,6 +38,9 @@ U = TypeVar('U', bound=UUID)
 
 # Mapping type
 M = TypeVar('M', bound=Mapping)
+
+# DefaultDict type
+DD = TypeVar('DD', bound=DefaultDict)
 
 # Numeric type
 N = TypeVar('N', int, float, complex)

--- a/dataclass_wizard/type_def.py
+++ b/dataclass_wizard/type_def.py
@@ -7,11 +7,13 @@ __all__ = [
     'ExplicitNull',
     'NUMBERS',
     'T',
+    'E',
     'M',
     'N',
     'S'
 ]
 
+from enum import Enum
 from typing import TypeVar, Mapping, Sequence
 
 from .constants import PY36, PY38_OR_ABOVE
@@ -24,6 +26,9 @@ NUMBERS = int, float
 
 # Generic type
 T = TypeVar('T')
+
+# Enum subclass type
+E = TypeVar('E', bound=Enum)
 
 # Mapping type
 M = TypeVar('M', bound=Mapping)

--- a/dataclass_wizard/utils/string_conv.py
+++ b/dataclass_wizard/utils/string_conv.py
@@ -1,5 +1,6 @@
 __all__ = ['to_camel_case',
            'to_pascal_case',
+           'to_lisp_case',
            'to_snake_case']
 
 import re
@@ -37,6 +38,28 @@ def to_pascal_case(string):
 
     return string[0].upper() + re.sub(
         r"(?:_)(.)", lambda m: m.group(1).upper(), string[1:])
+
+
+def to_lisp_case(string: str) -> str:
+    """
+    Make a hyphenated, lowercase form from the expression in the string.
+
+    Example::
+
+        >>> to_lisp_case("DeviceType")
+        'device-type'
+
+    """
+    string = string.replace('_', '-')
+    # Short path: the field is already lower-cased, so we don't need to handle
+    # for camel or title case.
+    if string.islower():
+        return replace_multi_with_single(string, '-')
+
+    result = re.sub(
+        r'((?!^)(?<!-)[A-Z][a-z]+|(?<=[a-z0-9])[A-Z])', r'-\1', string)
+
+    return replace_multi_with_single(result.lower(), '-')
 
 
 def to_snake_case(string: str) -> str:

--- a/dataclass_wizard/utils/type_conv.py
+++ b/dataclass_wizard/utils/type_conv.py
@@ -2,19 +2,22 @@ __all__ = ['as_bool',
            'as_int',
            'as_str',
            'as_list',
+           'as_enum',
            'as_datetime',
            'as_date',
            'as_time',
            'date_to_timestamp']
 
 from datetime import datetime, time, date
+from enum import Enum
 from numbers import Number
-from typing import Union, List
+from typing import Union, List, Type, AnyStr, Optional
 
-from ..type_def import N, NUMBERS
+from ..errors import ParseError
+from ..type_def import E, N, NUMBERS
 
 
-# What values are considered "truthy" when converted to a boolean type.
+# What values are considered "truthy" when converting to a boolean type.
 # noinspection SpellCheckingInspection
 _TRUTHY_VALUES = ('TRUE', 'T', 'YES', 'Y', '1')
 
@@ -102,6 +105,68 @@ def as_list(o: Union[str, List[str]], sep=','):
         return o
 
     return o.split(sep)
+
+
+def as_enum(o: Union[AnyStr, N],
+            base_type: Type[E],
+            lookup_func=lambda base_type, o: base_type[o],
+            transform_func=lambda o: o.upper().replace(' ', '_'),
+            raise_=True
+            ) -> Optional[E]:
+    """
+    Return `o` if it's already an :class:`Enum` of type `base_type`. If `o` is
+    None or an empty string, return None.
+
+    Otherwise, attempt to convert the object `o` to a :type:`base_type` using
+    the below logic:
+
+        * If `o` is a string, we'll put it through our `transform_func` before
+          a lookup. The default one upper-cases the string and replaces spaces
+          with underscores, since that's typically how we define `Enum` names.
+
+        * Then, convert to a :type:`base_type` using the `lookup_func`. The
+          one looks up by the Enum ``name`` field.
+
+    :raises ParseError: If the lookup for the Enum member fails, and the
+      `raise_` flag is enabled.
+
+    """
+    if isinstance(o, base_type):
+        return o
+
+    if o is None:
+        return o
+
+    if o == '':
+        return None
+
+    key = transform_func(o) if isinstance(o, str) else o
+
+    try:
+        return lookup_func(base_type, key)
+
+    except KeyError:
+
+        if raise_:
+            from inspect import getsource
+
+            enum_cls_name = getattr(base_type, '__qualname__', base_type)
+            valid_values = getattr(base_type, '_member_names_', None)
+            # TODO this is to get the source code for the lambda function.
+            #   Might need to refactor into a helper func when time allows.
+            lookup_func_src = getsource(lookup_func).strip('\n, ').split(
+                'lookup_func=', 1)[-1]
+
+            e = ValueError(
+                f'as_enum: Unable to convert value to type {enum_cls_name!r}')
+
+            raise ParseError(e, o, base_type,
+                             valid_values=valid_values,
+                             lookup_key=key,
+                             lookup_func=lookup_func_src)
+
+        else:
+            return None
 
 
 def as_datetime(o: Union[str, Number, datetime],

--- a/dataclass_wizard/utils/wrappers.py
+++ b/dataclass_wizard/utils/wrappers.py
@@ -1,0 +1,19 @@
+"""
+Wrapper utilities
+"""
+from typing import Callable
+
+
+class FuncWrapper:
+    """
+    Wraps a callable `f` - which is occasionally useful, for example when
+    defining functions as :class:`Enum` values. See below answer for more
+    details.
+
+    https://stackoverflow.com/a/40339397/10237506
+    """
+    def __init__(self, f: Callable):
+        self.f = f
+
+    def __call__(self, *args, **kwargs):
+        return self.f(*args, **kwargs)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -38,7 +38,7 @@ Or download the `tarball`_:
 
 .. code-block:: console
 
-    $ curl -OJL https://github.com/rnag/dataclass-wizard/tarball/master
+    $ curl -OJL https://github.com/rnag/dataclass-wizard/tarball/main
 
 Once you have a copy of the source, you can install it with:
 
@@ -48,4 +48,4 @@ Once you have a copy of the source, you can install it with:
 
 
 .. _Github repo: https://github.com/rnag/dataclass-wizard
-.. _tarball: https://github.com/rnag/dataclass-wizard/tarball/master
+.. _tarball: https://github.com/rnag/dataclass-wizard/tarball/main

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.4.0
 commit = True
 tag = True
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,14 @@
+"""
+Common test fixtures and utilities.
+"""
+
+from uuid import UUID
+
+
+class MyUUIDSubclass(UUID):
+    """
+    Simple UUID subclass that calls :meth:`hex` when ``str()`` is invoked.
+    """
+
+    def __str__(self):
+        return self.hex

--- a/tests/unit/test_bases_meta.py
+++ b/tests/unit/test_bases_meta.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, date
 from typing import Optional, List
 
 import pytest
@@ -8,7 +8,8 @@ from pytest_mock import MockerFixture
 
 from dataclass_wizard import JSONSerializable, DumpMixin, LoadMixin
 from dataclass_wizard.enums import LetterCase, DateTimeTo
-
+from dataclass_wizard.errors import ParseError
+from dataclass_wizard.utils.type_conv import date_to_timestamp
 
 log = logging.getLogger(__name__)
 
@@ -16,6 +17,16 @@ log = logging.getLogger(__name__)
 @pytest.fixture
 def mock_log(mocker: MockerFixture):
     return mocker.patch('dataclass_wizard.bases_meta.LOG')
+
+
+@pytest.fixture
+def mock_meta_initializers(mocker: MockerFixture):
+    return mocker.patch('dataclass_wizard.bases_meta._META_INITIALIZER')
+
+
+@pytest.fixture
+def mock_get_dumper(mocker: MockerFixture):
+    return mocker.patch('dataclass_wizard.bases_meta.get_dumper')
 
 
 def test_meta_initializer_runs_as_expected(mock_log):
@@ -41,12 +52,14 @@ def test_meta_initializer_runs_as_expected(mock_log):
         class Meta(JSONSerializable.Meta):
             debug_enabled = True
             marshal_date_time_as = DateTimeTo.TIMESTAMP
+            key_transform_with_load = 'Camel'
             key_transform_with_dump = LetterCase.SNAKE
 
-        my_str: Optional[str]
-        list_of_int: List[int] = field(default_factory=list)
-        is_active: bool = False
-        my_dt: Optional[datetime] = None
+        myStr: Optional[str]
+        myDate: date
+        listOfInt: List[int] = field(default_factory=list)
+        isActive: bool = False
+        myDt: Optional[datetime] = None
 
     mock_log.info.assert_called_once_with('DEBUG Mode is enabled')
 
@@ -55,7 +68,8 @@ def test_meta_initializer_runs_as_expected(mock_log):
         "my_str": 20,
         "ListOfInt": ["1", "2", 3],
         "isActive": "true",
-        "my_dt": "2020-01-02T03:04:05"
+        "my_dt": "2020-01-02T03:04:05",
+        "my_date": "2010-11-30"
     }
     """
     c = MyClass.from_json(string)
@@ -64,18 +78,126 @@ def test_meta_initializer_runs_as_expected(mock_log):
     log.debug('Prettified JSON: %s', c)
 
     expected_dt = datetime(2020, 1, 2, 3, 4, 5)
+    expected_date = date(2010, 11, 30)
 
-    assert c.my_str == '20'
-    assert c.list_of_int == [1, 2, 3]
-    assert c.is_active
-    assert c.my_dt == expected_dt
+    assert c.myStr == '20'
+    assert c.listOfInt == [1, 2, 3]
+    assert c.isActive
+    assert c.myDate == expected_date
+    assert c.myDt == expected_dt
 
     d = c.to_dict()
 
     # Assert all JSON keys are converted to snake case
-    expected_json_keys = ['my_str', 'list_of_int', 'is_active', 'my_dt']
+    expected_json_keys = ['my_str', 'list_of_int', 'is_active',
+                          'my_date', 'my_dt']
     assert all(k in d for k in expected_json_keys)
 
-    # Assert that datetime objects are serialized to timestamps (int)
+    # Assert that date and datetime objects are serialized to timestamps (int)
+    assert isinstance(d['my_date'], int)
+    assert d['my_date'] == date_to_timestamp(expected_date)
     assert isinstance(d['my_dt'], int)
     assert d['my_dt'] == round(expected_dt.timestamp())
+
+
+def test_meta_initializer_is_called_when_meta_is_an_inner_class(
+        mock_meta_initializers):
+    """
+    Meta Initializer `dict` should be updated when `Meta` is an inner class.
+
+    Note: we're mocking the `__setitem__` for the meta initializers here, so
+    we don't need to inherit from :class:`LoadMixin` or :class:`DumpMixin`.
+    """
+    class _(JSONSerializable):
+        class _(JSONSerializable.Meta):
+            debug_enabled = True
+
+    mock_meta_initializers.__setitem__.assert_called_once()
+
+
+def test_meta_initializer_not_called_when_meta_is_not_an_inner_class(
+        mock_meta_initializers):
+    """
+    Meta Initializer `dict` should *not* be updated when `Meta` has no outer
+    class.
+
+    Note: we're mocking the `__setitem__` for the meta initializers here, so
+    we don't need to inherit from :class:`LoadMixin` or :class:`DumpMixin`.
+    """
+    class _(JSONSerializable.Meta):
+        debug_enabled = True
+
+    mock_meta_initializers.__setitem__.assert_not_called()
+
+
+def test_meta_initializer_errors_when_key_transform_with_load_is_invalid(
+        mock_log):
+    """
+    Test when an invalid value for the ``key_transform_with_load`` attribute
+    is specified when sub-classing from :class:`JSONSerializable.Meta`.
+
+    """
+    with pytest.raises(ParseError):
+
+        @dataclass
+        class _(JSONSerializable, LoadMixin, DumpMixin):
+            class Meta(JSONSerializable.Meta):
+                key_transform_with_load = 'Hello'
+
+            my_str: Optional[str]
+            list_of_int: List[int] = field(default_factory=list)
+
+
+def test_meta_initializer_errors_when_key_transform_with_dump_is_invalid(
+        mock_log):
+    """
+    Test when an invalid value for the ``key_transform_with_dump`` attribute
+    is specified when sub-classing from :class:`JSONSerializable.Meta`.
+
+    """
+    with pytest.raises(ParseError):
+
+        @dataclass
+        class _(JSONSerializable, LoadMixin, DumpMixin):
+            class Meta(JSONSerializable.Meta):
+                key_transform_with_dump = 'World'
+
+            my_str: Optional[str]
+            list_of_int: List[int] = field(default_factory=list)
+
+
+def test_meta_initializer_errors_when_marshal_date_time_as_is_invalid(
+        mock_log):
+    """
+    Test when an invalid value for the ``marshal_date_time_as`` attribute
+    is specified when sub-classing from :class:`JSONSerializable.Meta`.
+
+    """
+    with pytest.raises(ParseError):
+
+        @dataclass
+        class _(JSONSerializable, LoadMixin, DumpMixin):
+            class Meta(JSONSerializable.Meta):
+                marshal_date_time_as = 'iso'
+
+            my_str: Optional[str]
+            list_of_int: List[int] = field(default_factory=list)
+
+
+def test_meta_initializer_is_noop_when_marshal_date_time_as_is_iso_format(
+        mock_log, mock_get_dumper):
+    """
+    Test that it's a noop when the value for ``marshal_date_time_as``
+    is `ISO_FORMAT`, which is the default conversion method for the dumper
+    otherwise.
+
+    """
+    @dataclass
+    class _(JSONSerializable, LoadMixin, DumpMixin):
+        class Meta(JSONSerializable.Meta):
+            marshal_date_time_as = 'ISO Format'
+
+        my_str: Optional[str]
+        list_of_int: List[int] = field(default_factory=list)
+
+    mock_get_dumper().register_dump_hook.assert_not_called()

--- a/tests/unit/test_load.py
+++ b/tests/unit/test_load.py
@@ -12,9 +12,11 @@ from typing import List, Optional, Union, Tuple, Dict, NamedTuple, Type
 import pytest
 
 from dataclass_wizard import JSONSerializable
+from dataclass_wizard.class_helper import dataclass_fields
 from dataclass_wizard.errors import ParseError
 from dataclass_wizard.parsers import OptionalParser, Parser
 from dataclass_wizard.type_def import NoneType, T
+from .conftest import MyUUIDSubclass
 from ..conftest import *
 
 
@@ -69,6 +71,32 @@ def test_literal(input, expectation):
     with expectation:
         result = MyClass.from_dict(d)
         log.debug('Parsed object: %r', result)
+
+
+@pytest.mark.parametrize(
+    'input',
+    [
+        '12345678-1234-1234-1234-1234567abcde',
+        '{12345678-1234-5678-1234-567812345678}',
+        '12345678123456781234567812345678',
+        'urn:uuid:12345678-1234-5678-1234-567812345678'
+    ]
+)
+def test_uuid(input):
+
+    @dataclass
+    class MyUUIDTestClass(JSONSerializable):
+        my_id: MyUUIDSubclass
+
+    d = {'MyID': input}
+
+    result = MyUUIDTestClass.from_dict(d)
+    log.debug('Parsed object: %r', result)
+
+    expected = MyUUIDSubclass(input)
+
+    assert result.my_id == expected
+    assert isinstance(result.my_id, MyUUIDSubclass)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/utils/test_string_conv.py
+++ b/tests/unit/utils/test_string_conv.py
@@ -56,6 +56,30 @@ def test_to_pascal_case(string, expected):
 @pytest.mark.parametrize(
     'string,expected',
     [
+        ('device_type', 'device-type'),
+        ('IO_Error', 'io-error'),
+        ('isACamelCasedWORD', 'is-a-camel-cased-word'),
+        ('ATitledWordToTESTWith', 'a-titled-word-to-test-with'),
+        ('not-a-tester', 'not-a-tester'),
+        ('helloworld', 'helloworld'),
+        ('A', 'a'),
+        ('TESTing_if_thisWorks', 'tes-ting-if-this-works'),
+        ('a_B_Cde_fG_hi', 'a-b-cde-f-g-hi'),
+        ('ALL_CAPS', 'all-caps'),
+        ('WoRd', 'wo-rd'),
+        ('HIThereHOWIsItGoinG', 'hi-there-how-is-it-goin-g'),
+        ('How_-Are-_YoUDoing__TeST', 'how-are-yo-u-doing-te-st'),
+        ('thisIsWithANumber42ToTEST', 'this-is-with-a-number42-to-test')
+    ]
+)
+def test_to_lisp_case(string, expected):
+    actual = to_lisp_case(string)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'string,expected',
+    [
         ('device_type', 'device_type'),
         ('IO_Error', 'io_error'),
         ('isACamelCasedWORD', 'is_a_camel_cased_word'),


### PR DESCRIPTION
All changes are already documented in the [HISTORY.md](./HISTORY.md)

Main changes:

* Add support for serializing the following Python types:
    - ``defaultdict`` (via the ``typing.DefaultDict`` annotation)
    - ``UUID``'s
    - The special variadic form of ``Tuple``.
      For example, ``Tuple[str, ...]``.
    - A special case where optional type arguments are passed to ``Tuple``.
      For example, ``Tuple[str, Optional[int], Union[bool, str, None]]``
