### PR TITLE
v0.6.0: support set types, and custom JSON key mapping

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,25 @@
 History
 =======
 
+0.6.0 (2021-08-16)
+------------------
+
+* Support ``set`` and ``frozenset`` types in the JSON load and dump process,
+  as well as their equivalents in the ``typing`` module.
+* Support custom JSON key mappings for dataclass fields.
+* Add new exported helper functions:
+    - ``json_field``: This can be thought of as an alias to ``dataclasses.field(...)``,
+      but one which also represents a mapping of one or more JSON key names to a
+      dataclass field.
+    - ``json_key``: Represents a mapping of one or more JSON key names for a
+      dataclass field.
+* Add an optional attribute ``json_key_to_field`` to ``JSONSerializable.Meta``
+* Rename ``ListParser`` to ``IterableParser``, since this parser will also be
+  used for Set types.
+* Update the ``__call__`` method of the default ``Parser`` to raise a ``ParseError``,
+  so we can provide a more helpful error message when an unknown or unsupported type
+  annotation is encountered.
+
 0.5.1 (2021-08-13)
 ------------------
 **Bugfixes**

--- a/dataclass_wizard/__init__.py
+++ b/dataclass_wizard/__init__.py
@@ -74,6 +74,9 @@ __all__ = [
     'LoadMixin',
     'DumpMixin',
     'property_wizard',
+    # Models
+    'json_field',
+    'json_key'
 ]
 
 import logging
@@ -81,6 +84,7 @@ import logging
 from .constants import PY36
 from .dumpers import DumpMixin, setup_default_dumper
 from .loaders import LoadMixin, setup_default_loader
+from .models import json_field, json_key
 from .property_wizard import property_wizard
 from .serial_json import JSONSerializable
 

--- a/dataclass_wizard/__version__.py
+++ b/dataclass_wizard/__version__.py
@@ -6,7 +6,7 @@ __title__ = 'dataclass-wizard'
 __description__ = 'Marshal dataclasses to/from JSON and Python dict objects, ' \
                   'and add support for field properties with initial values.'
 __url__ = 'https://github.com/rnag/dataclass-wizard'
-__version__ = '0.5.1'
+__version__ = '0.6.0'
 __author__ = 'Ritvik Nag'
 __author_email__ = 'rv.kvetch@gmail.com'
 __license__ = 'Apache 2.0'

--- a/dataclass_wizard/abstractions.py
+++ b/dataclass_wizard/abstractions.py
@@ -7,10 +7,10 @@ from datetime import datetime, time, date
 from decimal import Decimal
 from typing import (
     Any, Type, Union, List, Tuple, NamedTupleMeta, Dict, SupportsFloat,
-    Optional, SupportsInt, FrozenSet, Sequence, AnyStr, TypeVar, Text, Callable
+    Optional, SupportsInt, FrozenSet, Sequence, AnyStr, TypeVar, Text, Callable, Set
 )
 
-from .type_def import M, N, T, E, U, DD
+from .type_def import M, N, T, E, U, DD, LS
 
 # Create a generic variable that can be 'AbstractJSONWizard', or any subclass.
 W = TypeVar('W', bound='AbstractJSONWizard')
@@ -187,12 +187,12 @@ class AbstractLoader(ABC):
 
     @staticmethod
     @abstractmethod
-    def load_to_list(
-            o: Union[List, Tuple], base_type: Type[List],
-            elem_parser: AbstractParser) -> List[Any]:
+    def load_to_list_or_set(
+            o: Union[List, Set, Tuple], base_type: Type[LS],
+            elem_parser: AbstractParser) -> LS:
         """
-        Load a list or tuple into a new object of type `base_type` (generally
-        a :class:`list` or a sub-class of one)
+        Load a list, set or tuple into a new object of type `base_type`
+        (generally a list, set, or a sub-class of one)
         """
 
     @classmethod

--- a/dataclass_wizard/bases_meta.py
+++ b/dataclass_wizard/bases_meta.py
@@ -5,11 +5,12 @@ both import directly from `bases`.
 
 """
 from datetime import datetime, date
-from typing import ClassVar, Type, Union, Optional
+from typing import ClassVar, Type, Union, Optional, Dict
 
 from .abstractions import W, AbstractJSONWizard
 from .class_helper import (
-    _META_INITIALIZER, get_outer_class_name, get_class_name, create_new_class
+    _META_INITIALIZER, get_outer_class_name, get_class_name, create_new_class, json_field_to_dataclass_field,
+    dataclass_field_to_json_field
 )
 from .decorators import try_with_load
 from .dumpers import get_dumper
@@ -23,13 +24,20 @@ from .utils.type_conv import date_to_timestamp, as_enum
 
 class BaseJSONWizardMeta:
 
-    # How should :class:`time` and :class:`datetime` objects be serialized
-    # when converted to a Python dictionary object or a JSON string.
-    marshal_date_time_as: ClassVar[Union[DateTimeTo, str]] = None
-
     # True to enable Debug mode for additional debug log output and more
     # helpful messages during error handling.
     debug_enabled: ClassVar[bool] = False
+
+    # A customized mapping of JSON keys to dataclass fields, that is used
+    # whenever `from_dict` or `from_json` is called.
+    #
+    # Note: this is in addition to the implicit field transformations, like
+    #   "myStr" -> "my_str"
+    json_key_to_field: Dict[str, str] = None
+
+    # How should :class:`time` and :class:`datetime` objects be serialized
+    # when converted to a Python dictionary object or a JSON string.
+    marshal_date_time_as: ClassVar[Union[DateTimeTo, str]] = None
 
     # How JSON keys should be transformed to dataclass fields.
     #
@@ -91,6 +99,35 @@ class BaseJSONWizardMeta:
         cls_loader = get_loader(outer_cls, create=create)
         cls_dumper = get_dumper(outer_cls, create=create)
 
+        if cls.debug_enabled:
+
+            LOG.setLevel('DEBUG')
+            LOG.info('DEBUG Mode is enabled')
+            # Decorate all hooks so they format more helpful messages
+            # on error.
+            load_hooks = cls_loader.__LOAD_HOOKS__
+            for typ in load_hooks:
+                load_hooks[typ] = try_with_load(load_hooks[typ])
+
+        if cls.json_key_to_field:
+            add_for_both = cls.json_key_to_field.pop('__all__', None)
+
+            json_field_to_dataclass_field(outer_cls).update(
+                cls.json_key_to_field
+            )
+
+            if add_for_both:
+                dataclass_to_json_field = dataclass_field_to_json_field(
+                    outer_cls)
+
+                # We unfortunately can't use a dict comprehension approach, as
+                # we don't know if there are multiple JSON keys mapped to a
+                # single dataclass field. So to be safe, we should only set
+                # the first JSON key mapped to each dataclass field.
+                for k, v in cls.json_key_to_field.items():
+                    if v not in dataclass_to_json_field:
+                        dataclass_to_json_field[v] = k
+
         if cls.marshal_date_time_as:
             enum_val = cls._safe_as_enum('marshal_date_time_as', DateTimeTo)
 
@@ -105,16 +142,6 @@ class BaseJSONWizardMeta:
                 # noop; the default dump hook for `datetime` and `date` already
                 # serializes using this approach.
                 pass
-
-        if cls.debug_enabled:
-
-            LOG.setLevel('DEBUG')
-            LOG.info('DEBUG Mode is enabled')
-            # Decorate all hooks so they format more helpful messages
-            # on error.
-            load_hooks = cls_loader.__LOAD_HOOKS__
-            for typ in load_hooks:
-                load_hooks[typ] = try_with_load(load_hooks[typ])
 
         if cls.key_transform_with_load:
 

--- a/dataclass_wizard/bases_meta.py
+++ b/dataclass_wizard/bases_meta.py
@@ -9,8 +9,8 @@ from typing import ClassVar, Type, Union, Optional, Dict
 
 from .abstractions import W, AbstractJSONWizard
 from .class_helper import (
-    _META_INITIALIZER, get_outer_class_name, get_class_name, create_new_class, json_field_to_dataclass_field,
-    dataclass_field_to_json_field
+    _META_INITIALIZER, get_outer_class_name, get_class_name, create_new_class,
+    json_field_to_dataclass_field, dataclass_field_to_json_field
 )
 from .decorators import try_with_load
 from .dumpers import get_dumper
@@ -33,6 +33,11 @@ class BaseJSONWizardMeta:
     #
     # Note: this is in addition to the implicit field transformations, like
     #   "myStr" -> "my_str"
+    #
+    # If the reverse mapping is also desired (i.e. dataclass field to JSON
+    # key), then specify the "__all__" key as a truthy value. If multiple JSON
+    # keys are specified for a dataclass field, only the first one provided is
+    # used in this case.
     json_key_to_field: Dict[str, str] = None
 
     # How should :class:`time` and :class:`datetime` objects be serialized
@@ -124,9 +129,9 @@ class BaseJSONWizardMeta:
                 # we don't know if there are multiple JSON keys mapped to a
                 # single dataclass field. So to be safe, we should only set
                 # the first JSON key mapped to each dataclass field.
-                for k, v in cls.json_key_to_field.items():
-                    if v not in dataclass_to_json_field:
-                        dataclass_to_json_field[v] = k
+                for json_key, field in cls.json_key_to_field.items():
+                    if field not in dataclass_to_json_field:
+                        dataclass_to_json_field[field] = json_key
 
         if cls.marshal_date_time_as:
             enum_val = cls._safe_as_enum('marshal_date_time_as', DateTimeTo)

--- a/dataclass_wizard/class_helper.py
+++ b/dataclass_wizard/class_helper.py
@@ -3,9 +3,11 @@ from dataclasses import Field, fields
 from typing import Dict, Tuple, Type, Union, Callable, Optional
 
 from .abstractions import W, AbstractLoader, AbstractDumper
+from .models import JSONField, JSON
 from .parsers import Parser
 from .type_def import ExplicitNullType, T
 from .utils.dict_helper import CaseInsensitiveDict
+from .utils.type_check import is_annotated, get_args
 
 
 # A cached mapping of fully qualified class name to the list of fields, as
@@ -23,6 +25,11 @@ _CLASS_TO_DUMPER: Dict[str, Type[AbstractDumper]] = {}
 #
 # Note: need to create a `ForwardRef` here, because Python 3.6 complains.
 _FIELD_NAME_TO_LOAD_PARSER: Dict[str, 'CaseInsensitiveDict[str, Parser]'] = {}
+
+# Since the dump process doesn't use Parsers currently, we use a sentinel
+# mapping to confirm if we need to setup the dump config for a dataclass
+# on an initial run.
+_IS_DUMP_CONFIG_SETUP: Dict[str, bool] = {}
 
 # A cached mapping, per dataclass, of JSON field to instance field name
 _JSON_FIELD_TO_DATACLASS_FIELD: Dict[
@@ -98,13 +105,108 @@ def dataclass_field_to_load_parser(
     name = get_class_name(cls)
 
     if name not in _FIELD_NAME_TO_LOAD_PARSER:
-        # Lookup the Parser (dispatcher) for each field based on its annotated
-        # type, and then cache it so we don't need to lookup each time.
-        _FIELD_NAME_TO_LOAD_PARSER[name] = CaseInsensitiveDict(
-            {f.name: cls_loader.get_parser_for_annotation(f.type, cls)
-             for f in dataclass_fields(cls)})
+        _setup_load_config_for_cls(cls_loader, cls, name)
 
     return _FIELD_NAME_TO_LOAD_PARSER[name]
+
+
+def _setup_load_config_for_cls(cls_loader, cls, name: str):
+    """
+    This function processes a class `cls` on an initial run, and sets up the
+    load process for `cls` by iterating over each dataclass field. For each
+    field, it performs the following tasks:
+
+        * Lookup the Parser (dispatcher) for the field based on its type
+          annotation, and then cache it so we don't need to lookup each time.
+
+        * Check if the field's annotation is of type ``Annotated``. If so,
+          we iterate over each ``Annotated`` argument and find any special
+          :class:`JSON` objects (this can also be set via the helper function
+          ``json_key``). Assuming we find it, the class-specific mapping of
+          JSON key to dataclass field name is then updated with the input
+          passed in to this object.
+
+        * Check if the field type is a :class:`JSONField` object (this can
+          also be set by the helper function ``json_field``). Assuming this is
+          the case, the class-specific mapping of JSON key to dataclass field
+          name is then updated with the input passed in to the :class:`JSON`
+          attribute.
+    """
+
+    json_to_dataclass_field = _JSON_FIELD_TO_DATACLASS_FIELD[name]
+    name_to_parser = {}
+
+    for f in dataclass_fields(cls):
+
+        # Lookup the Parser (dispatcher) for each field based on its annotated
+        # type, and then cache it so we don't need to lookup each time.
+        name_to_parser[f.name] = cls_loader.get_parser_for_annotation(
+            f.type, cls)
+
+        # Check if the field is a `JSONField` object. If so, update the
+        # class-specific mapping of JSON key to dataclass field name.
+        if isinstance(f, JSONField):
+            for key in f.json_key.keys:
+                json_to_dataclass_field[key] = f.name
+
+        # Check if the field annotation is an `Annotated` type. If so,
+        # look for any `JSON` objects in the arguments; for each object,
+        # update the class-specific mapping of JSON key to dataclass field
+        # name.
+        if is_annotated(f.type):
+            for extra in get_args(f.type)[1:]:
+                if isinstance(extra, JSON):
+                    for key in extra.keys:
+                        json_to_dataclass_field[key] = f.name
+
+    _FIELD_NAME_TO_LOAD_PARSER[name] = CaseInsensitiveDict(name_to_parser)
+
+
+def setup_dump_config_for_cls_if_needed(cls):
+    """
+    This function processes a class `cls` on an initial run, and sets up the
+    dump process for `cls` by iterating over each dataclass field. For each
+    field, it performs the following tasks:
+
+        * Check if the field's annotation is of type ``Annotated``. If so,
+          we iterate over each ``Annotated`` argument and find any special
+          :class:`JSON` objects (this can also be set via the helper function
+          ``json_key``). Assuming we find it, the class-specific mapping of
+          dataclass field name to JSON key is then updated with the input
+          passed in to this object.
+
+        * Check if the field type is a :class:`JSONField` object (this can
+          also be set by the helper function ``json_field``). Assuming this is
+          the case, the class-specific mapping of dataclass field name to JSON
+          key is then updated with the input passed in to the :class:`JSON`
+          attribute.
+    """
+
+    name = get_class_name(cls)
+
+    if name in _IS_DUMP_CONFIG_SETUP:
+        return
+
+    dataclass_to_json_field = _DATACLASS_FIELD_TO_JSON_FIELD[name]
+
+    for f in dataclass_fields(cls):
+
+        # Check if the field is a `JSONField` object. If so, update the
+        # class-specific mapping of dataclass field name to JSON key.
+        if isinstance(f, JSONField) and f.json_key.all:
+            dataclass_to_json_field[f.name] = f.json_key.keys[0]
+
+        # Check if the field annotation is an `Annotated` type. If so,
+        # look for any `JSON` objects in the arguments; for each object,
+        # update the class-specific mapping of dataclass field name to JSON
+        # key.
+        if is_annotated(f.type):
+            for extra in get_args(f.type)[1:]:
+                if isinstance(extra, JSON) and extra.all:
+                    dataclass_to_json_field[f.name] = extra.keys[0]
+
+    # Mark the dataclass as processed, as the initial dump process is set up.
+    _IS_DUMP_CONFIG_SETUP[name] = True
 
 
 def call_meta_initializer_if_needed(cls: Type[W]):

--- a/dataclass_wizard/dumpers.py
+++ b/dataclass_wizard/dumpers.py
@@ -22,7 +22,7 @@ from .bases import BaseDumpHook
 from .class_helper import (
     create_new_class,
     dataclass_fields, dataclass_field_to_json_field,
-    dataclass_to_dumper, set_class_dumper,
+    dataclass_to_dumper, set_class_dumper, setup_dump_config_for_cls_if_needed,
 )
 from .constants import _DUMP_HOOKS
 from .log import LOG
@@ -214,6 +214,10 @@ def asdict(obj, *, dict_factory=dict) -> Dict[str, Any]:
     # -- The following lines are added, and are not present in original implementation. --
     cls_dumper = get_dumper(obj)
     hooks = cls_dumper.__DUMP_HOOKS__
+
+    # Pass the class reference itself, since we know we have an instance of
+    # the class.
+    setup_dump_config_for_cls_if_needed(type(obj))
 
     # Call the optional hook that runs before we process the dataclass
     cls_dumper.__pre_as_dict__(obj)

--- a/dataclass_wizard/dumpers.py
+++ b/dataclass_wizard/dumpers.py
@@ -26,7 +26,7 @@ from .class_helper import (
 )
 from .constants import _DUMP_HOOKS
 from .log import LOG
-from .type_def import NoneType, DD
+from .type_def import NoneType, DD, LS
 from .utils.string_conv import to_camel_case
 
 
@@ -83,6 +83,13 @@ class DumpMixin(AbstractDumper, BaseDumpHook):
             dict_factory, hooks):
 
         return typ(_asdict_inner(v, dict_factory, hooks) for v in o)
+
+    @staticmethod
+    def dump_with_set(
+            o: Union[LS], _typ: Type[LS],
+            dict_factory, hooks):
+
+        return list(_asdict_inner(v, dict_factory, hooks) for v in o)
 
     @staticmethod
     def dump_with_named_tuple(
@@ -142,6 +149,8 @@ def setup_default_dumper(cls=DumpMixin):
     # Complex types
     cls.register_dump_hook(Enum, cls.dump_with_enum)
     cls.register_dump_hook(UUID, cls.dump_with_uuid)
+    cls.register_dump_hook(set, cls.dump_with_set)
+    cls.register_dump_hook(frozenset, cls.dump_with_set)
     cls.register_dump_hook(list, cls.dump_with_list_or_tuple)
     cls.register_dump_hook(tuple, cls.dump_with_list_or_tuple)
     cls.register_dump_hook(NamedTupleMeta, cls.dump_with_named_tuple)

--- a/dataclass_wizard/dumpers.py
+++ b/dataclass_wizard/dumpers.py
@@ -22,7 +22,8 @@ from .bases import BaseDumpHook
 from .class_helper import (
     create_new_class,
     dataclass_fields, dataclass_field_to_json_field,
-    dataclass_to_dumper, set_class_dumper, setup_dump_config_for_cls_if_needed,
+    dataclass_to_dumper, set_class_dumper,
+    setup_dump_config_for_cls_if_needed,
 )
 from .constants import _DUMP_HOOKS
 from .log import LOG

--- a/dataclass_wizard/models.py
+++ b/dataclass_wizard/models.py
@@ -7,25 +7,70 @@ _STR_COLLECTION = Union[str, Collection[str]]
 
 
 def json_key(*keys: str, all=False):
+    """
+    Represents a mapping of one or more JSON key names for a dataclass field.
+
+    This is only in *addition* to the default key transform; for example, a
+    JSON key appearing as "myField", "MyField" or "my-field" will already map
+    to a dataclass field "my_test_field" by default (assuming the key
+    transform converts to snake case).
+
+    The mapping to each JSON key name is case-sensitive, so passing "myfield"
+    will not match a "myField" key in a JSON string or a Python dict object.
+
+    :param keys: A list of one of more JSON keys to associate with the
+      dataclass field.
+    :param all: True to also associate the reverse mapping, i.e. from
+      dataclass field to JSON key. If multiple JSON keys are passed in, it
+      uses the first one provided in this case. This mapping is then used when
+      `to_dict` or `to_json` is called, instead of the default key transform.
+    """
+
     return JSON(*keys, all=all)
 
 
-# Constructor sets the same defaults for keyword arguments as
-# the `dataclasses.field` function.
-def json_field(json_keys: _STR_COLLECTION, *,
+def json_field(keys: _STR_COLLECTION, *,
                all=False,
                default=MISSING, default_factory=MISSING,
                init=True, repr=True,
                hash=None, compare=True, metadata=None):
+    """
+    This is a helper function that sets the same defaults for keyword
+    arguments as the ``dataclasses.field`` function. It can be thought of as
+    an alias to ``dataclasses.field(...)``, but one which also represents
+    a mapping of one or more JSON key names to a dataclass field.
+
+    This is only in *addition* to the default key transform; for example, a
+    JSON key appearing as "myField", "MyField" or "my-field" will already map
+    to a dataclass field "my_test_field" by default (assuming the key
+    transform converts to snake case).
+
+    The mapping to each JSON key name is case-sensitive, so passing "myfield"
+    will not match a "myField" key in a JSON string or a Python dict object.
+
+    `keys` is a string, or a collection (list, tuple, etc.) of strings. It
+    represents one of more JSON keys to associate with the dataclass field.
+
+    When `all` is passed as True (default is False), it will also associate
+    the reverse mapping, i.e. from dataclass field to JSON key. If multiple
+    JSON keys are passed in, it uses the first one provided in this case.
+    This mapping is then used when ``to_dict`` or ``to_json`` is called,
+    instead of the default key transform.
+    """
+
     if default is not MISSING and default_factory is not MISSING:
         raise ValueError('cannot specify both default and default_factory')
 
-    return JSONField(json_keys, all, default, default_factory, init, repr,
+    return JSONField(keys, all, default, default_factory, init, repr,
                      hash, compare, metadata)
 
 
 class JSON:
-    """Represents one or more mappings of JSON keys."""
+    """
+    Represents one or more mappings of JSON keys.
+
+    See the docs on the :func:`json_key` function for more info.
+    """
     __slots__ = ('keys',
                  'all')
 
@@ -35,7 +80,13 @@ class JSON:
 
 
 class JSONField(Field):
-    __slots__ = ('json_key',)
+    """
+    Alias to a :class:`dataclasses.Field`, but one which also represents a
+    mapping of one or more JSON key names to a dataclass field.
+
+    See the docs on the :func:`json_field` function for more info.
+    """
+    __slots__ = ('json_key', )
 
     def __init__(self,
                  keys: _STR_COLLECTION,

--- a/dataclass_wizard/models.py
+++ b/dataclass_wizard/models.py
@@ -1,0 +1,56 @@
+from dataclasses import Field, MISSING
+from typing import Union, Collection
+
+
+# Type for a string or a collection of strings.
+_STR_COLLECTION = Union[str, Collection[str]]
+
+
+def json_key(*keys: str, all=False):
+    return JSON(*keys, all=all)
+
+
+# Constructor sets the same defaults for keyword arguments as
+# the `dataclasses.field` function.
+def json_field(json_keys: _STR_COLLECTION, *,
+               all=False,
+               default=MISSING, default_factory=MISSING,
+               init=True, repr=True,
+               hash=None, compare=True, metadata=None):
+    if default is not MISSING and default_factory is not MISSING:
+        raise ValueError('cannot specify both default and default_factory')
+
+    return JSONField(json_keys, all, default, default_factory, init, repr,
+                     hash, compare, metadata)
+
+
+class JSON:
+    """Represents one or more mappings of JSON keys."""
+    __slots__ = ('keys',
+                 'all')
+
+    def __init__(self, *keys: str, all=False):
+        self.keys = keys
+        self.all = all
+
+
+class JSONField(Field):
+    __slots__ = ('json_key',)
+
+    def __init__(self,
+                 keys: _STR_COLLECTION,
+                 all=False,
+                 default=MISSING,
+                 default_factory=MISSING,
+                 init=True,
+                 repr=True,
+                 hash=None,
+                 compare=True,
+                 metadata=None):
+        super().__init__(
+            default, default_factory, init, repr, hash, compare, metadata)
+
+        if isinstance(keys, str):
+            keys = (keys,)
+
+        self.json_key = JSON(*keys, all=all)

--- a/dataclass_wizard/parsers.py
+++ b/dataclass_wizard/parsers.py
@@ -38,11 +38,14 @@ class Parser(AbstractParser):
             return self.hook(o, self.base_type)
 
         except TypeError:
-            err = TypeError('Provided type is not currently supported.')
-            raise ParseError(
-                err, o, self.base_type,
-                unsupported_type=self.base_type
-            )
+            if self.hook is None:
+                err = TypeError('Provided type is not currently supported.')
+                raise ParseError(
+                    err, o, self.base_type,
+                    unsupported_type=self.base_type
+                )
+            # Else, raise the original error.
+            raise
 
 
 @dataclass

--- a/dataclass_wizard/parsers.py
+++ b/dataclass_wizard/parsers.py
@@ -3,7 +3,7 @@ __all__ = ['Parser',
            'UnionParser',
            'OptionalParser',
            'ForwardRefParser',
-           'ListParser',
+           'IterableParser',
            'TupleParser',
            'VariadicTupleParser',
            'NamedTupleParser',
@@ -19,7 +19,7 @@ from dataclasses import dataclass, InitVar, field
 
 from .abstractions import AbstractParser
 from .errors import ParseError
-from .type_def import NoneType, PyForwardRef, T, M, S, DD
+from .type_def import NoneType, PyForwardRef, T, M, S, DD, LS
 from .utils.type_check import (
     get_origin, get_args, get_named_tuple_field_types,
     get_keys_for_typed_dict)
@@ -34,7 +34,15 @@ class Parser(AbstractParser):
     hook: Callable[[Any, Type[T]], T]
 
     def __call__(self, o: Any) -> T:
-        return self.hook(o, self.base_type)
+        try:
+            return self.hook(o, self.base_type)
+
+        except TypeError:
+            err = TypeError('Provided type is not currently supported.')
+            raise ParseError(
+                err, o, self.base_type,
+                unsupported_type=self.base_type
+            )
 
 
 @dataclass
@@ -155,11 +163,14 @@ class ForwardRefParser(AbstractParser):
 
 
 @dataclass
-class ListParser(AbstractParser):
-
-    base_type: Type[S]
+class IterableParser(AbstractParser):
+    """
+    Parser for a :class:`list` or a :class:`set` type, or a subclass of either
+    type.
+    """
+    base_type: Type[LS]
     get_parser: InitVar[GetParserType]
-    hook: Callable[[S, Type[list], AbstractParser], list]
+    hook: Callable[[LS, Type[LS], AbstractParser], LS]
     elem_parser: AbstractParser = field(init=False)
 
     def __post_init__(self, cls: Type[T], get_parser: GetParserType):
@@ -177,10 +188,10 @@ class ListParser(AbstractParser):
 
         self.elem_parser = get_parser(elem_type, cls)
 
-    def __call__(self, o: S) -> S:
+    def __call__(self, o: LS) -> LS:
         """
         Load an object `o` into a new object of type `base_type` (generally a
-        :class:`list` or a sub-class of one)
+        list, set, or a sub-class of one)
         """
         try:
             return self.hook(o, self.base_type, self.elem_parser)
@@ -189,7 +200,8 @@ class ListParser(AbstractParser):
             if not isinstance(o, self.base_type):
                 e = TypeError('Incorrect type for field')
                 raise ParseError(
-                    e, o, self.base_type, desired_type=list)
+                    e, o, self.base_type,
+                    desired_type=self.base_type)
             else:
                 raise
 

--- a/dataclass_wizard/property_wizard.py
+++ b/dataclass_wizard/property_wizard.py
@@ -10,6 +10,7 @@ from .utils.type_check import (
 
 
 AnnotationType = Dict[str, Type[T]]
+AnnotationReplType = Dict[str, str]
 
 
 def property_wizard(*args, **kwargs):
@@ -31,7 +32,7 @@ def property_wizard(*args, **kwargs):
     # For each property, we want to replace the annotation for the underscore-
     # leading field associated with that property with the 'public' field
     # name, and this mapping helps us keep a track of that.
-    annotation_repls: Dict[str, str] = {}
+    annotation_repls: AnnotationReplType = {}
 
     for f, val in cls_dict.items():
 
@@ -63,7 +64,7 @@ def property_wizard(*args, **kwargs):
 
 def _process_public_property(cls: Type, public_f: str, val: property,
                              annotations: AnnotationType,
-                             annotation_repls: Dict[str, str]):
+                             annotation_repls: AnnotationReplType):
     """
     Handles the case when the property is marked as 'public' (i.e. no leading
     underscore)
@@ -123,7 +124,7 @@ def _process_public_property(cls: Type, public_f: str, val: property,
 
 def _process_underscored_property(cls: Type, under_f: str, val: property,
                                   annotations: AnnotationType,
-                                  annotation_repls: Dict[str, str]):
+                                  annotation_repls: AnnotationReplType):
     """
     Handles the case when the property is marked as 'private' (i.e. leads with
     an underscore)
@@ -154,8 +155,8 @@ def _process_underscored_property(cls: Type, under_f: str, val: property,
         if hasattr(cls, public_f):
             # Get the value of the field without a leading underscore
             v = getattr(cls, public_f)
-            # Check if the value of the public field is a dataclass Field.
-            # If so, we can use the `default` if one is set.
+            # Check if the value of public field is a dataclass Field. If so,
+            # we can use the `default` or `default_factory` if one is set.
             if isinstance(v, Field):
                 fval = _process_field(annotations, public_f, v)[0]
             else:

--- a/dataclass_wizard/type_def.py
+++ b/dataclass_wizard/type_def.py
@@ -12,7 +12,8 @@ __all__ = [
     'M',
     'DD',
     'N',
-    'S'
+    'S',
+    'LS'
 ]
 
 from enum import Enum
@@ -47,6 +48,9 @@ N = TypeVar('N', int, float, complex)
 
 # Sequence type
 S = TypeVar('S', bound=Sequence)
+
+# List or Set type
+LS = TypeVar('LS', list, set, frozenset)
 
 # The class of the `None` singleton, cached for re-usability
 NoneType = type(None)

--- a/docs/dataclass_wizard.rst
+++ b/docs/dataclass_wizard.rst
@@ -100,6 +100,14 @@ dataclass\_wizard.log module
    :undoc-members:
    :show-inheritance:
 
+dataclass\_wizard.models module
+-------------------------------
+
+.. automodule:: dataclass_wizard.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 dataclass\_wizard.parsers module
 --------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.1
+current_version = 0.6.0
 commit = True
 tag = True
 

--- a/tests/unit/test_bases_meta.py
+++ b/tests/unit/test_bases_meta.py
@@ -48,11 +48,17 @@ def test_meta_initializer_runs_as_expected(mock_log):
 
         class Meta(JSONSerializable.Meta):
             debug_enabled = True
+            json_key_to_field = {
+                '__all__': True,
+                'my_json_str': 'myCustomStr',
+                'anotherJSONField': 'myCustomStr'
+            }
             marshal_date_time_as = DateTimeTo.TIMESTAMP
             key_transform_with_load = 'Camel'
             key_transform_with_dump = LetterCase.SNAKE
 
         myStr: Optional[str]
+        myCustomStr: str
         myDate: date
         listOfInt: List[int] = field(default_factory=list)
         isActive: bool = False
@@ -63,6 +69,7 @@ def test_meta_initializer_runs_as_expected(mock_log):
     string = """
     {
         "my_str": 20,
+        "my_json_str": "test that this is mapped to 'myCustomStr'",
         "ListOfInt": ["1", "2", 3],
         "isActive": "true",
         "my_dt": "2020-01-02T03:04:05",
@@ -78,6 +85,7 @@ def test_meta_initializer_runs_as_expected(mock_log):
     expected_date = date(2010, 11, 30)
 
     assert c.myStr == '20'
+    assert c.myCustomStr == "test that this is mapped to 'myCustomStr'"
     assert c.listOfInt == [1, 2, 3]
     assert c.isActive
     assert c.myDate == expected_date
@@ -87,7 +95,7 @@ def test_meta_initializer_runs_as_expected(mock_log):
 
     # Assert all JSON keys are converted to snake case
     expected_json_keys = ['my_str', 'list_of_int', 'is_active',
-                          'my_date', 'my_dt']
+                          'my_date', 'my_dt', 'my_json_str']
     assert all(k in d for k in expected_json_keys)
 
     # Assert that date and datetime objects are serialized to timestamps (int)

--- a/tests/unit/test_dump.py
+++ b/tests/unit/test_dump.py
@@ -4,12 +4,52 @@ from uuid import UUID
 
 import pytest
 
-from dataclass_wizard import JSONSerializable
+from dataclass_wizard import JSONSerializable, json_field, json_key
 from dataclass_wizard.errors import ParseError
 from ..conftest import *
 
 
 log = logging.getLogger(__name__)
+
+
+def test_to_dict_key_transform_with_json_field():
+
+    @dataclass
+    class MyClass(JSONSerializable):
+        my_str: str = json_field('myCustomStr', all=True)
+        my_bool: bool = json_field(('my_json_bool', 'myTestBool'), all=True)
+
+    value = 'Testing'
+    expected = {'myCustomStr': value, 'my_json_bool': True}
+
+    c = MyClass(my_str=value, my_bool=True)
+
+    result = c.to_dict()
+    log.info('Parsed object: %r', result)
+
+    assert result == expected
+
+
+def test_to_dict_key_transform_with_json_key():
+
+    @dataclass
+    class MyClass(JSONSerializable):
+        my_str: Annotated[str, json_key('myCustomStr', all=True)]
+        my_bool: Annotated[bool, json_key(
+            'my_json_bool', 'myTestBool', all=True)]
+
+    value = 'Testing'
+    expected = {'myCustomStr': value, 'my_json_bool': True}
+
+    c = MyClass(my_str=value, my_bool=True)
+
+    result = c.to_dict()
+    log.info('Parsed object: %r', result)
+
+    result = c.to_dict()
+    log.info('Parsed object: %r', result)
+
+    assert result == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_load.py
+++ b/tests/unit/test_load.py
@@ -7,7 +7,10 @@ import logging
 from collections import namedtuple, defaultdict
 from dataclasses import dataclass
 from datetime import datetime, date, time
-from typing import List, Optional, Union, Tuple, Dict, NamedTuple, Type, DefaultDict
+from typing import (
+    List, Optional, Union, Tuple, Dict, NamedTuple, Type, DefaultDict,
+    Set, FrozenSet
+)
 
 import pytest
 
@@ -51,6 +54,10 @@ def test_bool(input, expected):
 
 
 def test_from_dict_key_transform_with_json_field():
+    """
+    Specifying a custom mapping of JSON key to dataclass field, via the
+    `json_field` helper function.
+    """
 
     @dataclass
     class MyClass(JSONSerializable):
@@ -68,6 +75,10 @@ def test_from_dict_key_transform_with_json_field():
 
 
 def test_from_dict_key_transform_with_json_key():
+    """
+    Specifying a custom mapping of JSON key to dataclass field, via the
+    `json_key` helper function.
+    """
 
     @dataclass
     class MyClass(JSONSerializable):
@@ -82,6 +93,62 @@ def test_from_dict_key_transform_with_json_key():
 
     assert result.my_str == value
     assert result.my_bool is True
+
+
+@pytest.mark.parametrize(
+    'input,expected,expectation',
+    [
+        ([1, '2', 3], {1, 2, 3}, does_not_raise()),
+        ('TrUe', True, pytest.raises(ParseError)),
+        ((3.22, 2.11, 1.22), {3, 2, 1}, does_not_raise()),
+    ]
+)
+def test_set(input, expected, expectation):
+
+    @dataclass
+    class MyClass(JSONSerializable):
+        num_set: Set[int]
+        any_set: set
+
+    d = {'numSet': input, 'any_set': input}
+
+    with expectation:
+        result = MyClass.from_dict(d)
+        log.debug('Parsed object: %r', result)
+
+        assert isinstance(result.num_set, set)
+        assert isinstance(result.any_set, set)
+
+        assert result.num_set == expected
+        assert result.any_set == set(input)
+
+
+@pytest.mark.parametrize(
+    'input,expected,expectation',
+    [
+        ([1, '2', 3], {1, 2, 3}, does_not_raise()),
+        ('TrUe', True, pytest.raises(ParseError)),
+        ((3.22, 2.11, 1.22), {1, 2, 3}, does_not_raise()),
+    ]
+)
+def test_frozenset(input, expected, expectation):
+
+    @dataclass
+    class MyClass(JSONSerializable):
+        num_set: FrozenSet[int]
+        any_set: frozenset
+
+    d = {'numSet': input, 'any_set': input}
+
+    with expectation:
+        result = MyClass.from_dict(d)
+        log.debug('Parsed object: %r', result)
+
+        assert isinstance(result.num_set, frozenset)
+        assert isinstance(result.any_set, frozenset)
+
+        assert result.num_set == expected
+        assert result.any_set == frozenset(input)
 
 
 @pytest.mark.parametrize(
@@ -954,3 +1021,16 @@ def test_optional_parser_contains(input, expected):
 
     actual = input in optional_parser
     assert actual == expected
+
+
+def test_parser_with_unsupported_type():
+    """
+    Test case for :meth:`Parser.__call__` with an unknown or unsupported
+    type, added for code coverage.
+
+    """
+    base_type: Type[T] = str
+    mock_parser = Parser(None, base_type, hook=None)
+
+    with pytest.raises(ParseError):
+        _ = mock_parser('hello world')

--- a/tests/unit/test_load.py
+++ b/tests/unit/test_load.py
@@ -11,7 +11,7 @@ from typing import List, Optional, Union, Tuple, Dict, NamedTuple, Type, Default
 
 import pytest
 
-from dataclass_wizard import JSONSerializable
+from dataclass_wizard import JSONSerializable, json_field, json_key
 from dataclass_wizard.errors import ParseError
 from dataclass_wizard.parsers import OptionalParser, Parser
 from dataclass_wizard.type_def import NoneType, T
@@ -48,6 +48,40 @@ def test_bool(input, expected):
     log.debug('Parsed object: %r', result)
 
     assert result.my_bool == expected
+
+
+def test_from_dict_key_transform_with_json_field():
+
+    @dataclass
+    class MyClass(JSONSerializable):
+        my_str: str = json_field('myCustomStr')
+        my_bool: bool = json_field(('my_json_bool', 'myTestBool'))
+
+    value = 'Testing'
+    d = {'myCustomStr': value, 'myTestBool': 'true'}
+
+    result = MyClass.from_dict(d)
+    log.debug('Parsed object: %r', result)
+
+    assert result.my_str == value
+    assert result.my_bool is True
+
+
+def test_from_dict_key_transform_with_json_key():
+
+    @dataclass
+    class MyClass(JSONSerializable):
+        my_str: Annotated[str, json_key('myCustomStr')]
+        my_bool: Annotated[bool, json_key('my_json_bool', 'myTestBool')]
+
+    value = 'Testing'
+    d = {'myCustomStr': value, 'myTestBool': 'true'}
+
+    result = MyClass.from_dict(d)
+    log.debug('Parsed object: %r', result)
+
+    assert result.my_str == value
+    assert result.my_bool is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Support `set`, `frozenset`, and custom JSON key mappings for dataclass fields.