### PR TITLE
0.17.1 support future ann in property wizard

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.17.1 (2021-11-04)
+-------------------
+
+* ``property_wizard``: Update the metaclass to support `new-style annotations`_,
+  also via a ``__future__`` import declared at a the top of a module; this allows
+  `PEP 585`_ and `PEP 604`_ style annotations to be used in Python 3.7 and higher.
+
 0.17.0 (2021-10-28)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -90,8 +90,9 @@ Using the built-in JSON marshalling support for dataclasses:
 
 .. code:: python3
 
+    from __future__ import annotations
+
     from dataclasses import dataclass, field
-    from typing import Union
     from typing_extensions import Annotated
 
     from dataclass_wizard import property_wizard
@@ -100,24 +101,24 @@ Using the built-in JSON marshalling support for dataclasses:
     @dataclass
     class Vehicle(metaclass=property_wizard):
         # Note: The example below uses the default value from the `field` extra in
-        # the `Annotated` definition; if `wheels` were annotated as a `Union` type,
+        # the `Annotated` definition; if `wheels` were annotated as `int | str`,
         # it would default to 0, because `int` appears as the first type argument.
         #
         # Any right-hand value assigned to `wheels` is ignored as it is simply
         # re-declared by the property; here it is simply omitted for brevity.
-        wheels: Annotated[Union[int, str], field(default=4)]
+        wheels: Annotated[int | str, field(default=4)]
 
         # This is a shorthand version of the above; here an IDE suggests
         # `_wheels` as a keyword argument to the constructor method, though
         # it will actually be named as `wheels`.
-        # _wheels: Union[int, str] = 4
+        # _wheels: int | str = 4
 
         @property
         def wheels(self) -> int:
             return self._wheels
 
         @wheels.setter
-        def wheels(self, wheels: Union[int, str]):
+        def wheels(self, wheels: int | str):
             self._wheels = int(wheels)
 
 

--- a/README.rst
+++ b/README.rst
@@ -48,8 +48,7 @@ Using the built-in JSON marshalling support for dataclasses:
 
 .. code:: python3
 
-    # Note: This future import is not needed for Python 3.10+
-    from __future__ import annotations
+    from __future__ import annotations  # This can be removed in Python 3.10+
 
     from dataclasses import dataclass, field
 
@@ -90,7 +89,7 @@ Using the built-in JSON marshalling support for dataclasses:
 
 .. code:: python3
 
-    from __future__ import annotations
+    from __future__ import annotations  # This can be removed in Python 3.10+
 
     from dataclasses import dataclass, field
     from typing_extensions import Annotated

--- a/dataclass_wizard/__version__.py
+++ b/dataclass_wizard/__version__.py
@@ -7,7 +7,7 @@ __description__ = 'Marshal dataclasses to/from JSON. Use field properties ' \
                   'with initial values. Construct a dataclass schema with ' \
                   'JSON input.'
 __url__ = 'https://github.com/rnag/dataclass-wizard'
-__version__ = '0.17.0'
+__version__ = '0.17.1'
 __author__ = 'Ritvik Nag'
 __author_email__ = 'rv.kvetch@gmail.com'
 __license__ = 'Apache 2.0'

--- a/dataclass_wizard/utils/typing_compat.py
+++ b/dataclass_wizard/utils/typing_compat.py
@@ -133,6 +133,7 @@ if not PY36:    # pragma: no cover
         _BASE_GENERIC_TYPES = (
             typing._GenericAlias,
             typing._SpecialForm,
+            types.GenericAlias,
             types.UnionType,
         )
 
@@ -293,9 +294,7 @@ def is_generic(cls):
 
     https://stackoverflow.com/a/52664522/10237506
     """
-    if isinstance(cls, _BASE_GENERIC_TYPES) or _get_origin(cls):
-        return True
-    return False
+    return isinstance(cls, _BASE_GENERIC_TYPES)
 
 
 def is_base_generic(cls):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.0
+current_version = 0.17.1
 commit = True
 tag = True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ __all__ = [
     'does_not_raise',
     'data_file_path',
     'PY36',
+    'PY39_OR_ABOVE',
+    'PY310_OR_ABOVE',
     # For compatibility with Python 3.6 and 3.7
     'Literal',
     'TypedDict',

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,11 +9,12 @@ from ..conftest import PY36
 
 
 if PY36:
-    # Ignore this file, because Python 3.6 doesn't define the `__future__`
-    # import used, so we'll run into an error if we import this module.
+    # Ignore these files, because Python 3.6 doesn't define the `__future__`
+    # import used, so we'll run into an error if we import these modules.
     #
     # Ref: https://docs.pytest.org/en/6.2.x/example/pythoncollection.html#customizing-test-collection
-    collect_ignore = ['test_load_with_future_import.py']
+    collect_ignore = ['test_load_with_future_import.py',
+                      'test_property_wizard_with_future_import.py']
 
 
 class MyUUIDSubclass(UUID):

--- a/tests/unit/test_property_wizard.py
+++ b/tests/unit/test_property_wizard.py
@@ -7,7 +7,7 @@ from typing import Union, List, ClassVar, DefaultDict, Set
 import pytest
 
 from dataclass_wizard import property_wizard
-from ..conftest import Literal, Annotated, PY39_OR_ABOVE
+from ..conftest import Literal, Annotated, PY39_OR_ABOVE, PY310_OR_ABOVE
 
 log = logging.getLogger(__name__)
 
@@ -192,6 +192,44 @@ def test_property_wizard_with_public_property_and_field():
         # The value of `wheels` here will be ignored, since `wheels` is simply
         # re-assigned on the following property definition.
         wheels: Union[int, str] = 4
+
+        @property
+        def wheels(self) -> int:
+            return self._wheels
+
+        @wheels.setter
+        def wheels(self, wheels: Union[int, str]):
+            self._wheels = int(wheels)
+
+    v = Vehicle()
+    log.debug(v)
+    assert v.wheels == 0
+
+    v = Vehicle(wheels=3)
+    log.debug(v)
+    assert v.wheels == 3
+
+    v = Vehicle('6')
+    log.debug(v)
+    assert v.wheels == 6, 'The constructor should use our setter method'
+
+    v.wheels = '123'
+    assert v.wheels == 123, 'Expected assignment to use the setter method'
+
+
+@pytest.mark.skipif(not PY310_OR_ABOVE, reason='requires Python 3.10 or higher')
+def test_property_wizard_with_public_property_and_field_with_or():
+    """
+    Using `property_wizard` when the dataclass has both a property and field
+    name *without* a leading underscore, and using the OR ("|") operator in
+    Python 3.10+, instead of the `typing.Union` usage.
+    """
+    @dataclass
+    class Vehicle(metaclass=property_wizard):
+
+        # The value of `wheels` here will be ignored, since `wheels` is simply
+        # re-assigned on the following property definition.
+        wheels: int | str = 4
 
         @property
         def wheels(self) -> int:

--- a/tests/unit/test_property_wizard_with_future_import.py
+++ b/tests/unit/test_property_wizard_with_future_import.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from dataclass_wizard import property_wizard
+
+
+log = logging.getLogger(__name__)
+
+
+def test_property_wizard_with_public_property_and_field_with_or():
+    """
+    Using `property_wizard` when the dataclass has both a property and field
+    name *without* a leading underscore, and using the OR ("|") operator,
+    instead of the `typing.Union` usage.
+    """
+    @dataclass
+    class Vehicle(metaclass=property_wizard):
+
+        # The value of `wheels` here will be ignored, since `wheels` is simply
+        # re-assigned on the following property definition.
+        wheels: int | str = 4
+
+        @property
+        def wheels(self) -> int:
+            return self._wheels
+
+        @wheels.setter
+        def wheels(self, wheels: int | str):
+            self._wheels = int(wheels)
+
+    v = Vehicle()
+    log.debug(v)
+    assert v.wheels == 0
+
+    v = Vehicle(wheels=3)
+    log.debug(v)
+    assert v.wheels == 3
+
+    v = Vehicle('6')
+    log.debug(v)
+    assert v.wheels == 6, 'The constructor should use our setter method'
+
+    v.wheels = '123'
+    assert v.wheels == 123, 'Expected assignment to use the setter method'
+
+
+def test_property_wizard_with_unresolvable_forward_ref():
+    """
+    Using `property_wizard` when the annotated field for a property references
+    a class or type that is not yet declared.
+    """
+    @dataclass
+    class Vehicle(metaclass=property_wizard):
+
+        # The value of `cars` here will be ignored, since `cars` is simply
+        # re-assigned on the following property definition.
+        cars: list[Car] = field(default_factory=list)
+        trucks: list[Truck] = field(default_factory=list)
+
+        @property
+        def cars(self) -> int:
+            return self._cars
+
+        @cars.setter
+        def cars(self, cars: list[Car]):
+            self._cars = cars * 2 if cars else cars
+
+    @dataclass
+    class Car:
+        spare_tires: int
+
+    class Truck:
+        ...
+
+    v = Vehicle()
+    log.debug(v)
+    assert v.cars is None
+
+    v = Vehicle([Car(1)])
+    log.debug(v)
+    assert v.cars == [Car(1), Car(1)], 'The constructor should use our ' \
+                                       'setter method'
+
+    v.cars = [Car(3)]
+    assert v.cars == [Car(3), Car(3)], 'Expected assignment to use the ' \
+                                       'setter method'


### PR DESCRIPTION
Update the `property_wizard` to support future (new-style) annotations in Python 3.7+