### PR TITLE
v0.19.0: support auto assign tags

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,22 @@
 History
 =======
 
+0.19.0 (2021-11-17)
+-------------------
+
+**Features and Improvements**
+
+* Add the option to customize the name of the *tag* key that will be used to
+  (de)serialize fields that contain dataclasses within ``Union`` types. A new
+  attribute :attr:`tag_key` in the ``Meta`` config determines the key in the
+  JSON object that will be used for this purpose, which defaults to ``__tag__`` if not specified.
+
+* Add the ability to *auto-generate* tags for a class - using the name of
+  the class - if a value for :attr:`tag` is not specified in the ``Meta`` config
+  for a dataclass that appears within a ``Union`` declaration. A new flag
+  :attr:`auto_assign_tags` in the ``Meta`` config can be enabled to allow
+  auto-assigning the class name as a tag.
+
 0.18.0 (2021-11-14)
 -------------------
 

--- a/dataclass_wizard/__version__.py
+++ b/dataclass_wizard/__version__.py
@@ -7,7 +7,7 @@ __description__ = 'Marshal dataclasses to/from JSON. Use field properties ' \
                   'with initial values. Construct a dataclass schema with ' \
                   'JSON input.'
 __url__ = 'https://github.com/rnag/dataclass-wizard'
-__version__ = '0.18.0'
+__version__ = '0.19.0'
 __author__ = 'Ritvik Nag'
 __author_email__ = 'rv.kvetch@gmail.com'
 __license__ = 'Apache 2.0'

--- a/dataclass_wizard/bases.py
+++ b/dataclass_wizard/bases.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from typing import Callable, Type, Dict, Optional, ClassVar, Union, TypeVar
 
+from .constants import TAG
 from .decorators import cached_class_property
 from .enums import DateTimeTo, LetterCase
 from .type_def import FrozenKeys
@@ -174,13 +175,25 @@ class AbstractMeta(metaclass=ABCOrAndMeta):
 
     # The field name that identifies the tag for a class.
     #
-    # When set to a value, a '__tag__' field will be populated in the
+    # When set to a value, an :attr:`TAG` field will be populated in the
     # dictionary object in the dump (serialization) process. When loading
-    # (or de-serializing) a dictionary object, the '__tag__' field will be
+    # (or de-serializing) a dictionary object, the :attr:`TAG` field will be
     # used to load the corresponding dataclass, assuming the dataclass field
     # is properly annotated as a Union type, ex.:
     #   my_data: Union[Data1, Data2, Data3]
     tag: ClassVar[str] = None
+
+    # The dictionary key that identifies the tag field for a class. This is
+    # only set when the `tag` field or the `auto_assign_tags` flag is enabled
+    # in the `Meta` config for a dataclass.
+    #
+    # Defaults to '__tag__' if not specified.
+    tag_key: ClassVar[str] = TAG
+
+    # Auto-assign the class name as a dictionary "tag" key, for any dataclass
+    # fields which are in a `Union` declaration, ex.:
+    #   my_data: Union[Data1, Data2, Data3]
+    auto_assign_tags: ClassVar[bool] = False
 
     # Determines whether we should we skip / omit fields with default values
     # (based on the `default` or `default_factory` argument specified for

--- a/dataclass_wizard/bases.py
+++ b/dataclass_wizard/bases.py
@@ -110,7 +110,7 @@ class AbstractMeta(metaclass=ABCOrAndMeta):
     })
 
     # Class attribute which enables us to detect a `JSONWizard.Meta` subclass.
-    __is_inner_meta__: ClassVar[bool] = False
+    __is_inner_meta__ = False
 
     # True to enable Debug mode for additional (more verbose) log output.
     #

--- a/dataclass_wizard/class_helper.py
+++ b/dataclass_wizard/class_helper.py
@@ -111,19 +111,22 @@ def dataclass_field_to_json_field(cls):
 def dataclass_field_to_load_parser(
         cls_loader: Type[AbstractLoader],
         cls: Type,
-        config: M) -> 'DictWithLowerStore[str, AbstractParser]':
+        config: M,
+        save: bool = True) -> 'DictWithLowerStore[str, AbstractParser]':
     """
     Returns a mapping of each lower-cased field name to its annotated type.
     """
     if cls not in _FIELD_NAME_TO_LOAD_PARSER:
-        _setup_load_config_for_cls(cls_loader, cls, config)
+        return _setup_load_config_for_cls(cls_loader, cls, config, save)
 
     return _FIELD_NAME_TO_LOAD_PARSER[cls]
 
 
 def _setup_load_config_for_cls(cls_loader: Type[AbstractLoader],
                                cls: Type,
-                               config: M):
+                               config: M,
+                               save: bool = True
+                               ) -> 'DictWithLowerStore[str, AbstractParser]':
     """
     This function processes a class `cls` on an initial run, and sets up the
     load process for `cls` by iterating over each dataclass field. For each
@@ -181,7 +184,12 @@ def _setup_load_config_for_cls(cls_loader: Type[AbstractLoader],
                     for key in extra.keys:
                         json_to_dataclass_field[key] = f.name
 
-    _FIELD_NAME_TO_LOAD_PARSER[cls] = DictWithLowerStore(name_to_parser)
+    parser_dict = DictWithLowerStore(name_to_parser)
+    # only cache the load parser for the class if `save` is enabled
+    if save:
+        _FIELD_NAME_TO_LOAD_PARSER[cls] = parser_dict
+
+    return parser_dict
 
 
 def setup_dump_config_for_cls_if_needed(cls: Type):

--- a/dataclass_wizard/constants.py
+++ b/dataclass_wizard/constants.py
@@ -40,5 +40,9 @@ SINGLE_ARG_ALIAS = '__SINGLE_ARG_ALIAS__'
 IDENTITY = '__IDENTITY__'
 
 # The dictionary key that identifies the tag field for a class. This is only
-# set when the `tag` field is enabled in the `Meta` config for a dataclass.
+# set when the `tag` field or the `auto_assign_tags` flag is enabled in the
+# `Meta` config for a dataclass.
+#
+# Note that this key can also be customized in the `Meta` config for a class,
+# via the :attr:`tag_key` field.
 TAG = '__tag__'

--- a/dataclass_wizard/decorators.py
+++ b/dataclass_wizard/decorators.py
@@ -19,7 +19,6 @@ class cached_class_property(object):
     def __init__(self, func):
         self.__func__ = func
         self.__attr_name__ = func.__name__
-        self.d = None
 
     def __get__(self, instance, cls=None):
         """This method is only called the first time, to cache the value."""

--- a/dataclass_wizard/dumpers.py
+++ b/dataclass_wizard/dumpers.py
@@ -291,6 +291,9 @@ def dump_func_for_dataclass(cls: Type[T],
     # A collection of field names in the dataclass.
     field_names = dataclass_field_names(cls)
 
+    # Tag key to populate when a dataclass is in a `Union` with other types.
+    tag_key = meta.tag_key or TAG
+
     def cls_asdict(obj: T, dict_factory=dict,
                    exclude: List[str] = None,
                    skip_defaults=meta.skip_defaults) -> JSONObject:
@@ -353,7 +356,7 @@ def dump_func_for_dataclass(cls: Type[T],
         Adds a tag field when `tag` field is passed in Meta.
         """
         result = cls_asdict(obj, dict_factory, exclude, **kwargs)
-        result[TAG] = meta.tag
+        result[tag_key] = meta.tag
 
         return result
 

--- a/docs/common_use_cases/meta.rst
+++ b/docs/common_use_cases/meta.rst
@@ -100,6 +100,18 @@ does not matter, but for demo purposes it's named the same as the base class her
             #   my_data: Union[Data1, Data2, Data3]
             tag = ''
 
+            # The dictionary key that identifies the tag field for a class. This is
+            # only set when the `tag` field or the `auto_assign_tags` flag is enabled
+            # in the `Meta` config for a dataclass.
+            #
+            # Defaults to '__tag__' if not specified.
+            tag_key = ''
+
+            # Auto-assign the class name as a dictionary "tag" key, for any dataclass
+            # fields which are in a `Union` declaration, ex.:
+            #   my_data: Union[Data1, Data2, Data3]
+            auto_assign_tags = False
+
             # Determines whether we should we skip / omit fields with default values
             # (based on the `default` or `default_factory` argument specified for
             # the :func:`dataclasses.field`) in the serialization process.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.18.0
+current_version = 0.19.0
 commit = True
 tag = True
 

--- a/tests/unit/test_load_with_future_import.py
+++ b/tests/unit/test_load_with_future_import.py
@@ -12,7 +12,6 @@ from dataclass_wizard import JSONWizard
 from dataclass_wizard.errors import ParseError
 from ..conftest import *
 
-
 log = logging.getLogger(__name__)
 
 
@@ -40,21 +39,21 @@ class DummyClass:
     'input,expectation',
     [
         # Wrong type: `my_field1` is passed in a float (not in valid Union types)
-        ({'my_field1': 3.1, 'my_field2': [], 'my_field3': (3, )}, pytest.raises(ParseError)),
+        ({'my_field1': 3.1, 'my_field2': [], 'my_field3': (3,)}, pytest.raises(ParseError)),
         # Wrong type: `my_field3` is passed a float type
         ({'my_field1': 3, 'my_field2': [], 'my_field3': 2.1}, pytest.raises(ParseError)),
         # Wrong type: `my_field3` is passed a list type
         ({'my_field1': 3, 'my_field2': [], 'my_field3': [1]}, pytest.raises(ParseError)),
         # Wrong type: `my_field3` is passed in a tuple of float (invalid Union type)
-        ({'my_field1': 3, 'my_field2': [], 'my_field3': (1.0, )}, pytest.raises(ParseError)),
+        ({'my_field1': 3, 'my_field2': [], 'my_field3': (1.0,)}, pytest.raises(ParseError)),
         # OK: `my_field3` is passed in a tuple of int (one of the valid Union types)
-        ({'my_field1': 3, 'my_field2': [], 'my_field3': (1, )}, does_not_raise()),
+        ({'my_field1': 3, 'my_field2': [], 'my_field3': (1,)}, does_not_raise()),
         # Wrong number of elements for `my_field3`: expected only one
         ({'my_field1': 3, 'my_field2': [], 'my_field3': (1, 2)}, pytest.raises(ParseError)),
         # Type checks for all fields
         ({'my_field1': 'string',
           'my_field2': [{'date_field': None}],
-          'my_field3': ('hello world', )}, does_not_raise()),
+          'my_field3': ('hello world',)}, does_not_raise()),
 
     ]
 )
@@ -70,7 +69,7 @@ def test_load_with_future_annotation_v1(input, expectation):
     class A(JSONWizard):
         my_field1: bool | str | int
         my_field2: list[B]
-        my_field3: int  |  tuple[str|int]  |  bool
+        my_field3: int | tuple[str | int] | bool
 
     with expectation:
         result = A.from_dict(input)
@@ -111,10 +110,155 @@ def test_load_with_future_annotation_v2(input, expectation):
 
     @dataclass
     class A(JSONWizard):
-        my_field1: Decimal | datetime.date|str
-        my_field2: str|Optional[int]
+        my_field1: Decimal | datetime.date | str
+        my_field2: str | Optional[int]
         my_field3: dict[str | int, list[B | C | Optional[D]]]
 
     with expectation:
         result = A.from_dict(input)
         log.debug('Parsed object: %r', result)
+
+
+def test_dataclasses_in_union_types():
+    """Dataclasses in Union types when manually specifying `tag` value."""
+
+    @dataclass
+    class Container(JSONWizard):
+        class _(JSONWizard.Meta):
+            key_transform_with_dump = 'SNAKE'
+
+        my_data: Data
+        my_dict: dict[str, A | B]
+
+    @dataclass
+    class Data:
+        my_str: str
+        my_list: list[C | D]
+
+    @dataclass
+    class A(JSONWizard):
+        class _(JSONWizard.Meta):
+            tag = 'AA'
+
+        val: str
+
+    @dataclass
+    class B(JSONWizard):
+        class _(JSONWizard.Meta):
+            tag = 'BB'
+
+        val: int
+
+    @dataclass
+    class C(JSONWizard):
+        class _(JSONWizard.Meta):
+            tag = '_C_'
+
+        my_field: int
+
+    @dataclass
+    class D(JSONWizard):
+        class _(JSONWizard.Meta):
+            tag = '_D_'
+
+        my_field: float
+
+    # Fix so the forward reference works
+    globals().update(locals())
+
+    c = Container.from_dict({
+        'my_data': {
+            'myStr': 'string',
+            'MyList': [{'__tag__': '_D_', 'my_field': 1.23},
+                       {'__tag__': '_C_', 'my_field': 3.21}]
+        },
+        'my_dict': {
+            'key': {'__tag__': 'AA',
+                    'val': '123'}
+        }
+    })
+
+    expected_obj = Container(
+        my_data=Data(my_str='string',
+                     my_list=[D(my_field=1.23),
+                              C(my_field=3)]),
+        my_dict={'key': A(val='123')}
+    )
+
+    expected_dict = {
+        "my_data": {"my_str": "string",
+                    "my_list": [{"my_field": 1.23, "__tag__": "_D_"},
+                                {"my_field": 3, "__tag__": "_C_"}]},
+        "my_dict": {"key": {"val": "123", "__tag__": "AA"}}
+    }
+
+    assert c == expected_obj
+    assert c.to_dict() == expected_dict
+
+
+def test_dataclasses_in_union_types_with_auto_assign_tags():
+    """
+    Dataclasses in Union types with auto-assign tags, and a custom tag field.
+    """
+    @dataclass
+    class Container(JSONWizard):
+        class _(JSONWizard.Meta):
+            key_transform_with_dump = 'SNAKE'
+            tag_key = 'type'
+            auto_assign_tags = True
+
+        my_data: Data
+        my_dict: dict[str, A | B]
+
+    @dataclass
+    class Data:
+        my_str: str
+        my_list: list[C | D]
+
+    @dataclass
+    class A:
+        val: str
+
+    @dataclass
+    class B:
+        val: int
+
+    @dataclass
+    class C:
+        my_field: int
+
+    @dataclass
+    class D:
+        my_field: float
+
+    # Fix so the forward reference works
+    globals().update(locals())
+
+    c = Container.from_dict({
+        'my_data': {
+            'myStr': 'string',
+            'MyList': [{'type': 'D', 'my_field': 1.23},
+                       {'type': 'C', 'my_field': 3.21}]
+        },
+        'my_dict': {
+            'key': {'type': 'A',
+                    'val': '123'}
+        }
+    })
+
+    expected_obj = Container(
+        my_data=Data(my_str='string',
+                     my_list=[D(my_field=1.23),
+                              C(my_field=3)]),
+        my_dict={'key': A(val='123')}
+    )
+
+    expected_dict = {
+        "my_data": {"my_str": "string",
+                    "my_list": [{"my_field": 1.23, "type": "D"},
+                                {"my_field": 3, "type": "C"}]},
+        "my_dict": {"key": {"val": "123", "type": "A"}}
+    }
+
+    assert c == expected_obj
+    assert c.to_dict() == expected_dict


### PR DESCRIPTION
So basically, `dataclass-wizard` has supported using dataclasses in `Union` definitions - i.e. like `Union[Class1, Class2, ...]` since a recent version, but I'd ideally like so simply the logic for handling such cases if at all possible. I envision two much needed changes as it pertains to this topic:

* **I want to add the ability to "auto-generate" tags for a class,** based on the name of the class, if a `tag` field is not specified in the *Meta* config for a class that appears within a `Union` type. I'd like to do this by adding a new configurable field `auto_assign_tags` in the Meta config, which is a flag that can be enabled to allow auto-assigning of tags to classes in `Union` types. The great thing is, since we added support for recursive Meta config in the last version, we just need to enable this flag on the main dataclass, and it should automatically cascade down and apply to each nested dataclass. Tell me that's not pretty cool.
* **I'd also like to make it possible to customize the name of the tag key;** right now it's hardcoded to a value like `__tag__` which looks a little bit unseemly in a JSON object, and so it'd be nice to update it on a per-class basis to something another name, like just "tag" for example. A field added to the Meta config such as `tag_key` should do perfectly for this; and it'll default to the `__tag__` key as mentioned, if one is not specified for a class explicitly.

Here's an example of how this would work (note I also added a unit test based on this sample):

```python3
from __future__ import annotations  # This can be removed in Python 3.10+

from dataclasses import dataclass

from dataclass_wizard import JSONWizard


@dataclass
class Container(JSONWizard):

    class _(JSONWizard.Meta):
        tag_key = 'type'
        auto_assign_tags = True

    my_data: Data
    my_dict: dict[str, A | B]


@dataclass
class Data:
    my_list: list[C | D]


@dataclass
class A:
    val: str


@dataclass
class B:
    val: int


@dataclass
class C:
    my_field: int


@dataclass
class D:
    my_field: float


def main():
    c = Container.from_dict({
        'my_data': {
            'MyList': [{'type': 'D', 'my_field': 1.23},
                       {'type': 'C', 'my_field': 3.21}]
        },
        'myDict': {
            'key': {'type': 'A',
                    'val': '123'}
        }
    })

    expected_obj = Container(
        my_data=Data(my_list=[D(my_field=1.23),
                              C(my_field=3)]),
        my_dict={'key': A(val='123')}
    )

    expected_dict = {
        "myData": {"myList": [{"myField": 1.23, "type": "D"},
                              {"myField": 3, "type": "C"}]},
        "myDict": {"key": {"val": "123", "type": "A"}}
    }

    assert c == expected_obj
    assert c.to_dict() == expected_dict


if __name__ == '__main__':
    main()
```

## TODO:

I'll still need to write up documentation on how to use these new features.