### PR TITLE
v0.21.0: Add Wizard Mixin classes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,25 @@
 History
 =======
 
+0.21.0 (2022-01-23)
+-------------------
+
+**Features and Improvements**
+
+* Adds few extra Wizard Mixin classes that might prove incredibly convenient to use.
+
+    - :class:`JSONListWizard` - Extends :class:`JSONWizard` to return *Container* -- instead of *list* -- objects where possible.
+    - :class:`JSONFileWizard` - Makes it easier to convert dataclass instances from/to JSON files on a local drive.
+    - :class:`YAMLWizard` - Provides support to convert dataclass instances to/from YAML, using the default PyYAML parser.
+
+* Add a new :class:`Container` model class, a *list* sub-type which acts as a convenience wrapper around a collection of dataclass instances.
+
+* The ``dataclass-wizard`` library now supports parsing of YAML data. It adds the `PyYAML`_ as an optional dependency, which is loaded when it's used for the initial time. This extra dependency can be installed via::
+
+      $ pip install dataclass-wizard[yaml]
+
+.. _PyYAML: https://pypi.org/project/PyYAML/
+
 0.20.3 (2021-11-30)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -85,13 +85,21 @@ Features
 
 Here are the supported features that ``dataclass-wizard`` currently provides:
 
--  *JSON (de)serialization*: marshal dataclasses to/from JSON and Python
+-  *JSON/YAML (de)serialization*: marshal dataclasses to/from JSON, YAML, and Python
    ``dict`` objects.
 -  *Field properties*: support for using properties with default
    values in dataclass instances.
 -  *JSON to Dataclass generation*: construct a dataclass schema with a JSON file
    or string input.
 
+Wizard Mixins
+-------------
+
+In addition to the ``JSONWizard``, here a few extra Mixin_ classes that might prove incredibly convenient to use.
+
+* `JSONListWizard`_ -- Extends ``JSONWizard`` to return `Container`_ -- instead of *list* -- objects where possible.
+* `JSONFileWizard`_ -- Makes it easier to convert dataclass instances from/to JSON files on a local drive.
+* `YAMLWizard`_ -- Provides support to convert dataclass instances to/from YAML, using the default ``PyYAML`` parser.
 
 Supported Types
 ---------------
@@ -881,6 +889,10 @@ This package was created with Cookiecutter_ and the `rnag/cookiecutter-pypackage
 .. _`rnag/cookiecutter-pypackage`: https://github.com/rnag/cookiecutter-pypackage
 .. _`Contributing`: https://dataclass-wizard.readthedocs.io/en/latest/contributing.html
 .. _`open an issue`: https://github.com/rnag/dataclass-wizard/issues
+.. _`JSONListWizard`: https://dataclass-wizard.readthedocs.io/en/latest/common_use_cases/wizard_mixins.html#jsonlistwizard
+.. _`JSONFileWizard`: https://dataclass-wizard.readthedocs.io/en/latest/common_use_cases/wizard_mixins.html#jsonfilewizard
+.. _`YAMLWizard`: https://dataclass-wizard.readthedocs.io/en/latest/common_use_cases/wizard_mixins.html#yamlwizard
+.. _`Container`: https://dataclass-wizard.readthedocs.io/en/latest/dataclass_wizard.html#dataclass_wizard.Container
 .. _`Supported Types`: https://dataclass-wizard.readthedocs.io/en/latest/overview.html#supported-types
 .. _`Mixin`: https://stackoverflow.com/a/547714/10237506
 .. _`Meta`: https://dataclass-wizard.readthedocs.io/en/latest/common_use_cases/meta.html

--- a/dataclass_wizard/__init__.py
+++ b/dataclass_wizard/__init__.py
@@ -75,6 +75,9 @@ __all__ = [
     'LoadMixin',
     'DumpMixin',
     'property_wizard',
+    # Wizard Mixins
+    'JSONListWizard',
+    'JSONFileWizard',
     # Helper serializer functions + meta config
     'fromlist',
     'fromdict',
@@ -84,6 +87,7 @@ __all__ = [
     # Models
     'json_field',
     'json_key',
+    'Container',
     'Pattern',
     'DatePattern',
     'TimePattern',
@@ -96,10 +100,11 @@ from .bases_meta import LoadMeta, DumpMeta
 from .constants import PY36
 from .dumpers import DumpMixin, setup_default_dumper, asdict
 from .loaders import LoadMixin, setup_default_loader, fromlist, fromdict
-from .models import (json_field, json_key,
+from .models import (json_field, json_key, Container,
                      Pattern, DatePattern, TimePattern, DateTimePattern)
 from .property_wizard import property_wizard
 from .serial_json import JSONSerializable
+from .wizard_mixins import JSONListWizard, JSONFileWizard
 
 
 # Set up logging to ``/dev/null`` like a library is supposed to.
@@ -119,5 +124,7 @@ setup_default_dumper()
 
 if PY36:    # pragma: no cover
     # Python 3.6 requires a backport for `datetime.fromisoformat()`
+    # noinspection PyPackageRequirements
+    # noinspection PyUnresolvedReferences
     from backports.datetime_fromisoformat import MonkeyPatch
     MonkeyPatch.patch_fromisoformat()

--- a/dataclass_wizard/__init__.py
+++ b/dataclass_wizard/__init__.py
@@ -78,6 +78,7 @@ __all__ = [
     # Wizard Mixins
     'JSONListWizard',
     'JSONFileWizard',
+    'YAMLWizard',
     # Helper serializer functions + meta config
     'fromlist',
     'fromdict',
@@ -104,7 +105,7 @@ from .models import (json_field, json_key, Container,
                      Pattern, DatePattern, TimePattern, DateTimePattern)
 from .property_wizard import property_wizard
 from .serial_json import JSONSerializable
-from .wizard_mixins import JSONListWizard, JSONFileWizard
+from .wizard_mixins import JSONListWizard, JSONFileWizard, YAMLWizard
 
 
 # Set up logging to ``/dev/null`` like a library is supposed to.

--- a/dataclass_wizard/__version__.py
+++ b/dataclass_wizard/__version__.py
@@ -7,7 +7,7 @@ __description__ = 'Marshal dataclasses to/from JSON. Use field properties ' \
                   'with initial values. Construct a dataclass schema with ' \
                   'JSON input.'
 __url__ = 'https://github.com/rnag/dataclass-wizard'
-__version__ = '0.20.3'
+__version__ = '0.21.0'
 __author__ = 'Ritvik Nag'
 __author_email__ = 'rv.kvetch@gmail.com'
 __license__ = 'Apache 2.0'

--- a/dataclass_wizard/abstractions.py
+++ b/dataclass_wizard/abstractions.py
@@ -1,6 +1,7 @@
 """
 Contains implementations for Abstract Base Classes
 """
+import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, InitVar
 from datetime import datetime, time, date, timedelta
@@ -10,10 +11,9 @@ from typing import (
     Text, Sequence, Iterable
 )
 
-from .bases import META
 from .models import Extras
 from .type_def import (
-    DefFactory, FrozenKeys, ListOfJSONObject, JSONObject,
+    DefFactory, FrozenKeys, ListOfJSONObject, JSONObject, Encoder,
     M, N, T, NT, E, U, DD, LSQ
 )
 
@@ -66,14 +66,21 @@ class AbstractJSONWizard(ABC):
         """
 
     @abstractmethod
-    def to_json(self: W, indent=None) -> AnyStr:
+    def to_json(self: W, *,
+                encoder: Encoder = json.dumps,
+                indent=None,
+                **encoder_kwargs) -> AnyStr:
         """
         Converts the dataclass instance to a JSON `string` representation.
         """
 
     @classmethod
     @abstractmethod
-    def list_to_json(cls: Type[W], instances: List[W], indent=None) -> AnyStr:
+    def list_to_json(cls: Type[W],
+                     instances: List[W],
+                     encoder: Encoder = json.dumps,
+                     indent=None,
+                     **encoder_kwargs) -> AnyStr:
         """
         Converts a ``list`` of dataclass instances to a JSON `string`
         representation.

--- a/dataclass_wizard/decorators.py
+++ b/dataclass_wizard/decorators.py
@@ -34,6 +34,26 @@ class cached_class_property(object):
         return attr
 
 
+class cached_property(object):
+    """
+    Descriptor decorator implementing an instance-level, read-only property,
+    which caches the attribute on-demand on the first use.
+    """
+    def __init__(self, func):
+        self.__func__ = func
+        self.__attr_name__ = func.__name__
+
+    def __get__(self, instance, cls=None):
+        """This method is only called the first time, to cache the value."""
+        # Build the attribute.
+        attr = self.__func__(instance)
+
+        # Cache the value; hide ourselves.
+        setattr(instance, self.__attr_name__, attr)
+
+        return attr
+
+
 def try_with_load(f):
 
     @wraps(f)

--- a/dataclass_wizard/dumpers.py
+++ b/dataclass_wizard/dumpers.py
@@ -202,6 +202,7 @@ def get_dumper(cls=None, create=True) -> Type[DumpMixin]:
 def asdict(obj: T,
            *, cls=None, dict_factory=dict,
            exclude: List[str] = None, **kwargs) -> JSONObject:
+    # noinspection PyUnresolvedReferences
     """Return the fields of a dataclass instance as a new dictionary mapping
     field names to field values.
 
@@ -233,7 +234,6 @@ def asdict(obj: T,
     # if not _is_dataclass_instance(obj):
     #     raise TypeError("asdict() should be called on dataclass instances")
 
-    # -- The following lines are added, and are not present in original implementation. --
     cls = cls or type(obj)
 
     try:
@@ -242,7 +242,6 @@ def asdict(obj: T,
         dump = dump_func_for_dataclass(cls)
 
     return dump(obj, dict_factory, exclude, **kwargs)
-    # -- END --
 
 
 def dump_func_for_dataclass(cls: Type[T],

--- a/dataclass_wizard/errors.py
+++ b/dataclass_wizard/errors.py
@@ -202,13 +202,12 @@ class MissingData(ParseError):
     _TEMPLATE = ('Failure loading class `{cls}`. '
                  'Missing value for field (expected a dict, got None)\n'
                  '  dataclass field: {field!r}\n'
-                 '  resolution: annotate the field as an `Optional[{cls}]`')
+                 '  resolution: annotate the field as an '
+                 '`Optional[{inner_cls}]`')
 
-    def __init__(self, cls: Type, **kwargs):
-
-        super().__init__(self, None, cls)
-
-        self.class_name: str = self.name(cls)
+    def __init__(self, inner_cls: Type, **kwargs):
+        super().__init__(self, None, inner_cls, **kwargs)
+        self.inner_class_name: str = self.name(inner_cls)
 
     @staticmethod
     def name(obj) -> str:
@@ -219,6 +218,7 @@ class MissingData(ParseError):
     def message(self) -> str:
         msg = self._TEMPLATE.format(
             cls=self.class_name,
+            inner_cls=self.inner_class_name,
             json_string=json.dumps(self.obj),
             field=self.field_name,
             o=self.obj,

--- a/dataclass_wizard/errors.py
+++ b/dataclass_wizard/errors.py
@@ -203,11 +203,11 @@ class MissingData(ParseError):
                  'Missing value for field (expected a dict, got None)\n'
                  '  dataclass field: {field!r}\n'
                  '  resolution: annotate the field as '
-                 '`Optional[{inner_cls}]` or `{inner_cls} | None`')
+                 '`Optional[{nested_cls}]` or `{nested_cls} | None`')
 
-    def __init__(self, inner_cls: Type, **kwargs):
-        super().__init__(self, None, inner_cls, **kwargs)
-        self.inner_class_name: str = self.name(inner_cls)
+    def __init__(self, nested_cls: Type, **kwargs):
+        super().__init__(self, None, nested_cls, **kwargs)
+        self.nested_class_name: str = self.name(nested_cls)
 
     @staticmethod
     def name(obj) -> str:
@@ -218,7 +218,7 @@ class MissingData(ParseError):
     def message(self) -> str:
         msg = self._TEMPLATE.format(
             cls=self.class_name,
-            inner_cls=self.inner_class_name,
+            nested_cls=self.nested_class_name,
             json_string=json.dumps(self.obj),
             field=self.field_name,
             o=self.obj,

--- a/dataclass_wizard/errors.py
+++ b/dataclass_wizard/errors.py
@@ -202,8 +202,8 @@ class MissingData(ParseError):
     _TEMPLATE = ('Failure loading class `{cls}`. '
                  'Missing value for field (expected a dict, got None)\n'
                  '  dataclass field: {field!r}\n'
-                 '  resolution: annotate the field as an '
-                 '`Optional[{inner_cls}]`')
+                 '  resolution: annotate the field as '
+                 '`Optional[{inner_cls}]` or `{inner_cls} | None`')
 
     def __init__(self, inner_cls: Type, **kwargs):
         super().__init__(self, None, inner_cls, **kwargs)

--- a/dataclass_wizard/lazy_imports.py
+++ b/dataclass_wizard/lazy_imports.py
@@ -10,3 +10,6 @@ from .utils.lazy_loader import LazyLoader
 
 # pytimeparse: for parsing JSON string values as a `datetime.timedelta`
 pytimeparse = LazyLoader(globals(), 'pytimeparse', 'timedelta')
+
+# PyYAML: to add support for (de)serializing YAML data to dataclass instances
+yaml = LazyLoader(globals(), 'yaml', 'yaml', local_name='PyYAML')

--- a/dataclass_wizard/loaders.py
+++ b/dataclass_wizard/loaders.py
@@ -634,9 +634,20 @@ def load_func_for_dataclass(
 
         except TypeError:
             # If the object `o` is None, then raise an error with the relevant
-            # info included. Else, just re-raise the error.
+            # info included.
             if o is None:
                 raise MissingData(cls) from None
+
+            # Check if the object `o` is some other type than what we expect -
+            # for example, we could be passed in a `list` type instead.
+            if not isinstance(o, dict):
+                e = TypeError('Incorrect type for field')
+                raise ParseError(
+                    e, o, dict,
+                    desired_type=dict
+                ) from None
+
+            #  Else, just re-raise the error.
             raise
 
         # Now pass the arguments to the constructor method, and return the new

--- a/dataclass_wizard/models.py
+++ b/dataclass_wizard/models.py
@@ -315,8 +315,10 @@ class Container(List[T]):
         >>> print(c.prettify())
 
     """
-    __slots__ = ('__dict__',
-                 '__orig_class__')
+
+    # TODO: Uncomment once we drop support for Python 3.6
+    # __slots__ = ('__dict__',
+    #              '__orig_class__')
 
     @cached_property
     def __model__(self) -> Type[T]:

--- a/dataclass_wizard/models.py
+++ b/dataclass_wizard/models.py
@@ -121,7 +121,7 @@ class JSONField(Field):
     # constructor: `kw_only`
     #
     # Ref: https://docs.python.org/3.10/library/dataclasses.html#dataclasses.dataclass
-    if PY310_OR_ABOVE:
+    if PY310_OR_ABOVE:  # pragma: no cover
         def __init__(self, keys: _STR_COLLECTION, all: bool, dump: bool,
                      default, default_factory, init, repr, hash, compare,
                      metadata):
@@ -134,7 +134,7 @@ class JSONField(Field):
 
             self.json = JSON(*keys, all=all, dump=dump)
 
-    else:
+    else:  # pragma: no cover
         def __init__(self, keys: _STR_COLLECTION, all: bool, dump: bool,
                      default, default_factory, init, repr, hash, compare,
                      metadata):

--- a/dataclass_wizard/models.py
+++ b/dataclass_wizard/models.py
@@ -327,6 +327,7 @@ class Container(List[T]):
         value of the generic type T.
         """
         try:
+            # noinspection PyUnresolvedReferences
             return self.__orig_class__.__args__[0]
         except AttributeError:
             cls_name = self.__class__.__qualname__

--- a/dataclass_wizard/serial_json.py
+++ b/dataclass_wizard/serial_json.py
@@ -95,6 +95,7 @@ class JSONSerializable(AbstractJSONWizard):
 
         return encoder(list_of_dict, **encoder_kwargs)
 
+    # noinspection PyShadowingBuiltins
     def __init_subclass__(cls, str=True):
         """
         Checks for optional settings and flags that may be passed in by the
@@ -116,5 +117,5 @@ def _str_fn():
     representation, when the `str()` method is invoked.
     """
     return _create_fn('__str__',
-                      ('self',),
+                      ('self', ),
                       ['return self.to_json(indent=2)'])

--- a/dataclass_wizard/type_def.py
+++ b/dataclass_wizard/type_def.py
@@ -15,7 +15,9 @@ __all__ = [
     'ListOfJSONObject',
     'JSONValue',
     'Encoder',
+    'FileEncoder',
     'Decoder',
+    'FileDecoder',
     'NUMBERS',
     'T',
     'E',
@@ -35,8 +37,8 @@ from collections import deque
 from datetime import date, time, datetime
 from enum import Enum
 from typing import (
-    Type, TypeVar, Sequence, Mapping,
-    List, DefaultDict, FrozenSet, NamedTuple, Callable, AnyStr, Dict, Any, Union
+    Any, Type, TypeVar, Sequence, Mapping, List, Dict, DefaultDict, FrozenSet,
+    Union, NamedTuple, Callable, AnyStr, TextIO, BinaryIO
 )
 from uuid import UUID
 
@@ -196,6 +198,18 @@ class Encoder(PyProtocol):
         ...
 
 
+class FileEncoder(PyProtocol):
+    """
+    Represents an encoder for Python object -> JSON file, e.g. analogous to
+    `json.dump`
+    """
+
+    def __call__(self, obj: Union[JSONObject, JSONList],
+                 file: Union[TextIO, BinaryIO],
+                 **kwargs) -> AnyStr:
+        ...
+
+
 class Decoder(PyProtocol):
     """
     Represents a decoder for JSON -> Python object, e.g. analogous to
@@ -203,5 +217,15 @@ class Decoder(PyProtocol):
     """
 
     def __call__(self, s: AnyStr,
+                 **kwargs) -> Union[JSONObject, ListOfJSONObject]:
+        ...
+
+
+class FileDecoder(PyProtocol):
+    """
+    Represents a decoder for JSON file -> Python object, e.g. analogous to
+    `json.load`
+    """
+    def __call__(self, file: Union[TextIO, BinaryIO],
                  **kwargs) -> Union[JSONObject, ListOfJSONObject]:
         ...

--- a/dataclass_wizard/utils/lazy_loader.py
+++ b/dataclass_wizard/utils/lazy_loader.py
@@ -34,7 +34,7 @@ class LazyLoader(types.ModuleType):
 
         except ModuleNotFoundError:
             # The lazy-loaded module is not currently installed.
-            msg = f'Unable to import the module `{self.__name__}`'
+            msg = f'Unable to import the module `{self._local_name}`'
 
             if self._extra:
                 from ..__version__ import __title__

--- a/dataclass_wizard/wizard_mixins.py
+++ b/dataclass_wizard/wizard_mixins.py
@@ -78,7 +78,7 @@ class JSONFileWizard:
 
         return fromdict(cls, o) if isinstance(o, dict) else fromlist(cls, o)
 
-    def to_json_file(self, file: str, mode: str = 'w',
+    def to_json_file(self: T, file: str, mode: str = 'w',
                      encoder: FileEncoder = json.dump,
                      **encoder_kwargs) -> None:
         """
@@ -132,14 +132,15 @@ class YAMLWizard:
 
         return encoder(asdict(self), **encoder_kwargs)
 
-    def to_yaml_file(self, file: str, mode: str = 'w',
+    def to_yaml_file(self: T, file: str, mode: str = 'w',
                      encoder: Optional[FileEncoder] = None,
                      **encoder_kwargs) -> None:
         """
         Serializes the instance and writes it to a YAML file.
         """
         with open(file, mode) as out_file:
-            self.to_yaml(stream=out_file)
+            self.to_yaml(stream=out_file, encoder=encoder,
+                         **encoder_kwargs)
 
     @classmethod
     def list_to_yaml(cls: Type[T],

--- a/dataclass_wizard/wizard_mixins.py
+++ b/dataclass_wizard/wizard_mixins.py
@@ -1,0 +1,82 @@
+import json
+from typing import Type, Union, AnyStr, List
+
+from .abstractions import W
+from .dumpers import asdict
+from .loaders import fromdict, fromlist
+from .models import Container
+from .serial_json import JSONSerializable
+from .type_def import ListOfJSONObject, Decoder, FileDecoder, FileEncoder
+
+
+class JSONListWizard(JSONSerializable, str=False):
+    """
+    A mixin class that extends :class:`JSONSerializable` (JSONWizard)
+    to return :class:`Container` - instead of `list` - objects.
+
+    Note that `Container` objects are simply convenience wrappers around a
+    collection of dataclass instances. For all intents and purposes, they
+    behave exactly the same as `list` objects, with some added helper methods:
+
+        * ``prettify`` - Convert the list of instances to a *prettified* JSON
+          string.
+
+        * ``to_json`` - Convert the list of instances to a JSON string.
+
+        * ``to_json_file`` - Serialize the list of instances and write it to a
+          JSON file.
+
+    """
+
+    @classmethod
+    def from_json(cls: Type[W], string: AnyStr, *,
+                  decoder: Decoder = json.loads,
+                  **decoder_kwargs) -> Union[W, Container[W]]:
+        """
+        Converts a JSON `string` to an instance of the dataclass, or a
+        Container (list) of the dataclass instances.
+        """
+        o = decoder(string, **decoder_kwargs)
+
+        if isinstance(o, dict):
+            return fromdict(cls, o)
+
+        return Container[cls](fromlist(cls, o))
+
+    @classmethod
+    def from_list(cls: Type[W], o: ListOfJSONObject) -> Container[W]:
+        """
+        Converts a Python `list` object to a Container (list) of the dataclass
+        instances.
+        """
+        return Container[cls](fromlist(cls, o))
+
+
+class JSONFileWizard:
+    """
+    A mixin class that makes it easier to interact with JSON files.
+
+    This can be paired with the :class:`JSONSerializable` (JSONWizard) mixin
+    class for complete extensibility.
+    """
+    @classmethod
+    def from_json_file(cls: Type[W], file: str, *,
+                       decoder: FileDecoder = json.load,
+                       **decoder_kwargs) -> Union[W, List[W]]:
+        """
+        Reads in the JSON file contents and converts to an instance of the
+        dataclass, or a list of the dataclass instances.
+        """
+        with open(file) as in_file:
+            o = decoder(in_file, **decoder_kwargs)
+
+        return fromdict(cls, o) if isinstance(o, dict) else fromlist(cls, o)
+
+    def to_json_file(self, file: str, mode: str = 'w',
+                     encoder: FileEncoder = json.dump,
+                     **encoder_kwargs) -> None:
+        """
+        Serializes the instance and writes it to a JSON file.
+        """
+        with open(file, mode) as out_file:
+            encoder(asdict(self), out_file, **encoder_kwargs)

--- a/docs/common_use_cases/wizard_mixins.rst
+++ b/docs/common_use_cases/wizard_mixins.rst
@@ -1,0 +1,192 @@
+Wizard Mixin Classes
+====================
+
+In addition to the :class:`JSONWizard`, here a few extra Wizard Mixin
+classes that might prove incredibly convenient to use.
+
+:class:`JSONListWizard`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The JSON List Wizard is a Mixin class that extends :class:`JSONWizard` to
+return :class:`Container` - instead of ``list`` - objects.
+
+.. note:: :class:`Container` objects are simply convenience wrappers around
+  a collection of dataclass instances. For all intents and purposes, they
+  behave exactly the same as ``list`` objects, with some added helper methods:
+
+    * :meth:`prettify` - Convert the list of instances to a *prettified* JSON
+      string.
+
+    * :meth:`to_json` - Convert the list of instances to a JSON string.
+
+    * :meth:`to_json_file` - Serialize the list of instances and write it to a
+      JSON file.
+
+Simple example of usage below:
+
+.. code:: python3
+
+    from __future__ import annotations  # Note: In 3.10+, this import can be removed
+
+    from dataclasses import dataclass
+
+    from dataclass_wizard import JSONListWizard, Container
+
+
+    @dataclass
+    class Outer(JSONListWizard):
+        my_str: str | None
+        inner: list[Inner]
+
+
+    @dataclass
+    class Inner:
+        other_str: str
+
+
+    my_list = [
+        {"my_str": 20,
+         "inner": [{"otherStr": "testing 123"}]},
+        {"my_str": "hello",
+         "inner": [{"otherStr": "world"}]},
+    ]
+
+    # De-serialize the JSON string into a list of `MyClass` objects
+    c = Outer.from_list(my_list)
+
+    # Container is just a sub-class of list
+    assert isinstance(c, list)
+    assert type(c) == Container
+
+    print(c)
+    # [Outer(my_str='20', inner=[Inner(other_str='testing 123')]),
+    #  Outer(my_str='hello', inner=[Inner(other_str='world')])]
+
+    print(c.prettify())
+    # [
+    #   {
+    #     "myStr": "20",
+    #   ...
+
+    # serializes the list of dataclass instances to a JSON file
+    c.to_json_file('my_file.json')
+
+:class:`JSONFileWizard`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The JSON File Wizard is a *minimalist* Mixin class that makes it easier
+to interact with JSON files, as shown below.
+
+It comes with only two added methods: :meth:`from_json_file` and
+:meth:`to_json_file`.
+
+.. note::
+  This can be paired with the :class:`JSONWizard` Mixin class for more
+  complete extensibility.
+
+.. code:: python3
+
+    from __future__ import annotations  # Note: In 3.10+, this import can be removed
+
+    from dataclasses import dataclass
+
+    from dataclass_wizard import JSONFileWizard
+
+
+    @dataclass
+    class MyClass(JSONFileWizard):
+        my_str: str | None
+        my_int: int = 14
+
+
+    c1 = MyClass(my_str='Hello, world!')
+    print(c1)
+
+    # Serializes the dataclass instance to a JSON file
+    c1.to_json_file('my_file.json')
+
+    # contents of my_file.json:
+    #> {"myStr": "Hello, world!", "myInt": 14}
+
+    c2 = MyClass.from_json_file('my_file.json')
+
+    # assert that data is the same
+    assert c1 == c2
+
+:class:`YAMLWizard`
+~~~~~~~~~~~~~~~~~~~
+
+The YAML Wizard leverages the `PyYAML`_ library -- which can be installed
+as an extra via ``pip install dataclass-wizard[yaml]`` -- to easily convert
+dataclass instances to/from YAML.
+
+.. note::
+  The default key transform used in the YAML dump process is `lisp-case`,
+  however this can easily be customized without the need to sub-class
+  from :class:`JSONWizard`, as shown below.
+
+      >>> @dataclass
+      >>> class MyClass(YAMLWizard, key_transform='CAMEL'):
+      >>>     ...
+
+A (mostly) complete example of using the :class:`YAMLWizard` is as follows:
+
+.. code:: python3
+
+    from __future__ import annotations  # Note: In 3.10+, this import can be removed
+
+    from dataclasses import dataclass, field
+
+    from dataclass_wizard import YAMLWizard
+
+
+    @dataclass
+    class MyClass(YAMLWizard):
+        str_or_num: str | int = 42
+        nested: MyNestedClass | None = None
+
+
+    @dataclass
+    class MyNestedClass:
+        list_of_map: list[dict[int, str]] = field(default_factory=list)
+        my_int: int = 14
+
+
+    c1 = MyClass.from_yaml("""
+    str-or-num: 23
+    nested:
+        ListOfMap:
+            - 111: Hello,
+              222: World!
+            - 333: 'Testing'
+              444: 123
+    """)
+
+    # serialize the dataclass instance to a YAML file
+    c1.to_yaml_file('my_file.yaml')
+
+    # sample contents of `my_file.yaml` would be:
+    #> nested:
+    #>   list-of-map:
+    #>   - 111: Hello,
+    #>   ...
+
+    # now read it back...
+    c2 = MyClass.from_yaml_file('my_file.yaml')
+
+    # assert we get back the same data
+    assert c1 == c2
+
+    # let's create a list of dataclass instances
+    objects = [MyClass(), c2, MyClass(3, nested=MyNestedClass())]
+
+    # and now, serialize them all...
+    yaml_string = MyClass.list_to_yaml(objects)
+
+    print(yaml_string)
+    #   str-or-num: 42
+    # - nested:
+    #     list-of-map:
+    #   ...
+
+.. _PyYAML: https://pypi.org/project/PyYAML/

--- a/docs/dataclass_wizard.rst
+++ b/docs/dataclass_wizard.rst
@@ -149,6 +149,14 @@ dataclass\_wizard.type\_def module
    :undoc-members:
    :show-inheritance:
 
+dataclass\_wizard.wizard\_mixins module
+---------------------------------------
+
+.. automodule:: dataclass_wizard.wizard_mixins
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,4 +17,4 @@ pytest-cov==3.0.0
 # Benchmark tests
 dataclasses-json==0.5.6
 jsons==1.6.0
-dataclass-factory==2.13
+dataclass-factory==2.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.20.3
+current_version = 0.21.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,8 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     extras_require={
-        'timedelta': ['pytimeparse>=1.1.7']
+        'timedelta': ['pytimeparse>=1.1.7'],
+        'yaml': ['PyYAML>=5.3']
     },
     zip_safe=False
 )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,11 +1,17 @@
 """
 Common test fixtures and utilities.
 """
-
-from pathlib import Path
+from dataclasses import dataclass
 from uuid import UUID
 
 from ..conftest import PY36
+
+
+@dataclass
+class SampleClass:
+    """Sample dataclass model for various test scenarios."""
+    f1: str
+    f2: int
 
 
 if PY36:

--- a/tests/unit/test_load.py
+++ b/tests/unit/test_load.py
@@ -1489,7 +1489,7 @@ def test_load_with_inner_model_when_data_is_null():
 
     e = exc_info.value
     assert e.class_name == Outer.__qualname__
-    assert e.inner_class_name == Inner.__qualname__
+    assert e.nested_class_name == Inner.__qualname__
     assert e.field_name == 'inner'
     # the error should mention that we want an Inner, but get a None
     assert e.ann_type is Inner

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,21 +1,14 @@
-from dataclasses import dataclass
-
 import pytest
 from pytest_mock import MockerFixture
 
 from dataclass_wizard import fromlist
 from dataclass_wizard.models import Container, json_field
+from .conftest import SampleClass
 
 
 @pytest.fixture
 def mock_open(mocker: MockerFixture):
     return mocker.patch('dataclass_wizard.models.open')
-
-
-@dataclass
-class A:
-    f1: str
-    f2: int
 
 
 def test_json_field_does_not_allow_both_default_and_default_factory():
@@ -43,9 +36,9 @@ def test_container_methods(mocker: MockerFixture, mock_open):
     list_of_dict = [{'f1': 'hello', 'f2': 1},
                     {'f1': 'world', 'f2': 2}]
 
-    list_of_a = fromlist(A, list_of_dict)
+    list_of_a = fromlist(SampleClass, list_of_dict)
 
-    c = Container[A](list_of_a)
+    c = Container[SampleClass](list_of_a)
 
     # The repr() is very short, so it would be expected to fit in one line,
     # which thus aligns with the output of `pprint.pformat`.

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+
+import pytest
+from pytest_mock import MockerFixture
+
+from dataclass_wizard import fromlist
+from dataclass_wizard.models import Container, json_field
+
+
+@pytest.fixture
+def mock_open(mocker: MockerFixture):
+    return mocker.patch('dataclass_wizard.models.open')
+
+
+@dataclass
+class A:
+    f1: str
+    f2: int
+
+
+def test_json_field_does_not_allow_both_default_and_default_factory():
+    """
+    Confirm we can't specify both `default` and `default_factory` when
+    calling the :func:`json_field` helper function.
+    """
+    with pytest.raises(ValueError):
+        _ = json_field((), default=None, default_factory=None)
+
+
+def test_container_with_incorrect_usage():
+    """Confirm an error is raised when wrongly instantiating a Container."""
+    c = Container()
+
+    with pytest.raises(TypeError) as exc_info:
+        _ = c.to_json()
+
+    err_msg = exc_info.exconly()
+    assert 'A Container object needs to be instantiated ' \
+           'with a generic type T' in err_msg
+
+
+def test_container_methods(mocker: MockerFixture, mock_open):
+    list_of_dict = [{'f1': 'hello', 'f2': 1},
+                    {'f1': 'world', 'f2': 2}]
+
+    list_of_a = fromlist(A, list_of_dict)
+
+    c = Container[A](list_of_a)
+
+    # The repr() is very short, so it would be expected to fit in one line,
+    # which thus aligns with the output of `pprint.pformat`.
+    assert str(c) == repr(c)
+
+    assert c.prettify() == """\
+[
+  {
+    "f1": "hello",
+    "f2": 1
+  },
+  {
+    "f1": "world",
+    "f2": 2
+  }
+]"""
+
+    assert c.to_json() == '[{"f1": "hello", "f2": 1}, {"f1": "world", "f2": 2}]'
+
+    mock_open.assert_not_called()
+    mock_encoder = mocker.Mock()
+
+    filename = 'my_file.json'
+    c.to_json_file(filename, encoder=mock_encoder)
+
+    mock_open.assert_called_once_with(filename, 'w')
+    mock_encoder.assert_called_once_with(list_of_dict, mocker.ANY)

--- a/tests/unit/test_wizard_mixins.py
+++ b/tests/unit/test_wizard_mixins.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass
+from typing import List, Optional, Dict
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -16,13 +19,25 @@ class MyFileWizard(SampleClass, JSONFileWizard):
     ...
 
 
+@dataclass
+class MyYAMLWizard(YAMLWizard):
+    my_str: str
+    inner: Optional['Inner'] = None
+
+
+@dataclass
+class Inner:
+    my_float: float
+    my_list: List[str]
+
+
 @pytest.fixture
 def mock_open(mocker: MockerFixture):
     return mocker.patch('dataclass_wizard.wizard_mixins.open')
 
 
 def test_json_list_wizard_methods():
-
+    """Test and coverage the base methods in JSONListWizard."""
     c1 = MyListWizard.from_json('{"f1": "hello", "f2": 111}')
     assert c1.__class__ is MyListWizard
 
@@ -36,9 +51,9 @@ def test_json_list_wizard_methods():
 
 
 def test_json_file_wizard_methods(mocker: MockerFixture, mock_open):
-
+    """Test and coverage the base methods in JSONFileWizard."""
     filename = 'my_file.json'
-    my_dict = {'f1': 'Hello world!','f2': 123}
+    my_dict = {'f1': 'Hello world!', 'f2': 123}
 
     mock_decoder = mocker.Mock()
     mock_decoder.return_value = my_dict
@@ -57,3 +72,107 @@ def test_json_file_wizard_methods(mocker: MockerFixture, mock_open):
 
     mock_open.assert_called_once_with(filename, 'w')
     mock_encoder.assert_called_once_with(my_dict, mocker.ANY)
+
+
+def test_yaml_wizard_methods(mocker: MockerFixture):
+    """Test and coverage the base methods in YAMLWizard."""
+    yaml_data = """\
+    my_str: test value
+    inner:
+        my_float: 1.2
+        my_list:
+            - hello, world!
+            - 123\
+    """
+
+    # Patch open() to return a file-like object which returns our string data.
+    m = mocker.patch('dataclass_wizard.wizard_mixins.open',
+                     mocker.mock_open(read_data=yaml_data))
+
+    filename = 'my_file.yaml'
+
+    obj = MyYAMLWizard.from_yaml_file(filename)
+
+    m.assert_called_once_with(filename)
+    m.reset_mock()
+
+    assert obj == MyYAMLWizard(my_str='test value',
+                               inner=Inner(my_float=1.2,
+                                           my_list=['hello, world!', '123']))
+
+    mock_open.return_value = mocker.mock_open()
+
+    obj.to_yaml_file(filename)
+
+    m.assert_called_once_with(filename, 'w')
+
+    # default key casing for the dump process will be `lisp-case`
+    m().write.assert_has_calls(
+        [mocker.call('my-str'),
+         mocker.call('inner'),
+         mocker.call('my-float'),
+         mocker.call('1.2'),
+         mocker.call('my-list'),
+         mocker.call('world!')],
+        any_order=True)
+
+
+def test_yaml_wizard_list_to_json():
+    """Test and coverage the `list_to_json` method in YAMLWizard."""
+    @dataclass
+    class MyClass(YAMLWizard, key_transform='SNAKE'):
+        my_str: str
+        my_dict: Dict[int, str]
+
+    yaml_string = MyClass.list_to_yaml([
+        MyClass('42', {111: 'hello', 222: 'world'}),
+        MyClass('testing!', {333: 'this is a test.'})
+    ])
+
+    assert yaml_string == """\
+- my_dict:
+    111: hello
+    222: world
+  my_str: '42'
+- my_dict:
+    333: this is a test.
+  my_str: testing!
+"""
+
+
+def test_yaml_wizard_for_branch_coverage(mocker: MockerFixture):
+    """
+    For branching logic in YAMLWizard, mainly for code coverage purposes.
+    """
+
+    # This is to coverage the `if` condition in the `__init_subclass__`
+    @dataclass
+    class MyClass(YAMLWizard, key_transform=None):
+        ...
+
+    # from_yaml: To cover the case of passing in `decoder`
+    mock_return_val = {'my_str': 'test string'}
+
+    mock_decoder = mocker.Mock()
+    mock_decoder.return_value = mock_return_val
+
+    result = MyYAMLWizard.from_yaml('my stream', decoder=mock_decoder)
+
+    assert result == MyYAMLWizard('test string')
+    mock_decoder.assert_called_once()
+
+    # to_yaml: To cover the case of passing in `encoder`
+    mock_encoder = mocker.Mock()
+    mock_encoder.return_value = mock_return_val
+
+    m = MyYAMLWizard('test string')
+    result = m.to_yaml(encoder=mock_encoder)
+
+    assert result == mock_return_val
+    mock_encoder.assert_called_once()
+
+    # list_to_yaml: To cover the case of passing in `encoder`
+    result = MyYAMLWizard.list_to_yaml([], encoder=mock_encoder)
+
+    assert result == mock_return_val
+    mock_encoder.assert_any_call([])

--- a/tests/unit/test_wizard_mixins.py
+++ b/tests/unit/test_wizard_mixins.py
@@ -1,0 +1,59 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from dataclass_wizard import Container
+from dataclass_wizard.wizard_mixins import (
+    JSONListWizard, JSONFileWizard, YAMLWizard
+)
+from .conftest import SampleClass
+
+
+class MyListWizard(SampleClass, JSONListWizard):
+    ...
+
+
+class MyFileWizard(SampleClass, JSONFileWizard):
+    ...
+
+
+@pytest.fixture
+def mock_open(mocker: MockerFixture):
+    return mocker.patch('dataclass_wizard.wizard_mixins.open')
+
+
+def test_json_list_wizard_methods():
+
+    c1 = MyListWizard.from_json('{"f1": "hello", "f2": 111}')
+    assert c1.__class__ is MyListWizard
+
+    c2 = MyListWizard.from_json('[{"f1": "hello", "f2": 111}]')
+    assert c2.__class__ is Container
+
+    c3 = MyListWizard.from_list([{"f1": "hello", "f2": 111}])
+    assert c3.__class__ is Container
+
+    assert c2 == c3
+
+
+def test_json_file_wizard_methods(mocker: MockerFixture, mock_open):
+
+    filename = 'my_file.json'
+    my_dict = {'f1': 'Hello world!','f2': 123}
+
+    mock_decoder = mocker.Mock()
+    mock_decoder.return_value = my_dict
+
+    c = MyFileWizard.from_json_file(filename,
+                                    decoder=mock_decoder)
+
+    mock_open.assert_called_once_with(filename)
+    mock_decoder.assert_called_once()
+
+    mock_encoder = mocker.Mock()
+    mock_open.reset_mock()
+
+    c.to_json_file(filename,
+                   encoder=mock_encoder)
+
+    mock_open.assert_called_once_with(filename, 'w')
+    mock_encoder.assert_called_once_with(my_dict, mocker.ANY)


### PR DESCRIPTION
This PR adds few extra *Mixin* classes that might prove incredibly convenient to use.

* `JSONListWizard` - Extends ``JSONWizard`` to return *Container* -- instead of *list* -- objects where possible.
* `JSONFileWizard` - Makes it easier to convert dataclass instances from/to JSON files on a local drive.
* `YAMLWizard` - Provides support to convert dataclass instances to/from YAML, using the default *PyYAML* parser.

---

That's right, this library now supports parsing of YAML data!

It adds the *PyYAML* as an optional dependency, which is only loaded when it's actually used for the initial time. This extra dependency can be installed via:

    pip install dataclass-wizard[yaml]

Here's a simple example of the intended usage below:

```python3
from dataclasses import dataclass

from dataclass_wizard import YAMLWizard


@dataclass
class MyClass(YAMLWizard, key_transform='SNAKE'):
    my_str: str
    my_int: int


yaml_string = """
my-str: string value
my-int: '21'
"""

c = MyClass.from_yaml(yaml_string)
print(c)
#> MyClass(my_str='string value', my_int=21)

string_val = c.to_yaml()
print(string_val)
#> my_int: 21
#> my_str: string value
```