### PR TITLE
Fix mypy type errors

### DIFF
--- a/dataclass_wizard/abstractions.py
+++ b/dataclass_wizard/abstractions.py
@@ -8,13 +8,13 @@ from datetime import datetime, time, date, timedelta
 from decimal import Decimal
 from typing import (
     Any, Type, TypeVar, Union, List, Tuple, Dict, SupportsFloat, AnyStr,
-    Text, Sequence, Iterable
+    Text, Sequence, Iterable, Generic
 )
 
 from .models import Extras
 from .type_def import (
     DefFactory, FrozenKeys, ListOfJSONObject, JSONObject, Encoder,
-    M, N, T, NT, E, U, DD, LSQ
+    M, N, T, TT, NT, E, U, DD, LSQ
 )
 
 
@@ -88,7 +88,7 @@ class AbstractJSONWizard(ABC):
 
 
 @dataclass
-class AbstractParser(ABC):
+class AbstractParser(ABC, Generic[T, TT]):
     """
     Abstract parsers, which will ideally act as dispatchers to route objects
     to the `load` or `dump` hook methods responsible for transforming the
@@ -119,7 +119,7 @@ class AbstractParser(ABC):
     # This is usually the underlying base type of the annotation (for example,
     # for `List[str]` it will be `list`), though in some cases this will be
     # the annotation itself.
-    base_type: Type[T]
+    base_type: T
 
     def __contains__(self, item) -> bool:
         """
@@ -130,7 +130,7 @@ class AbstractParser(ABC):
         return type(item) is self.base_type
 
     @abstractmethod
-    def __call__(self, o: Any):
+    def __call__(self, o: Any) -> TT:
         """
         Parse object `o`
         """

--- a/dataclass_wizard/bases.py
+++ b/dataclass_wizard/bases.py
@@ -8,10 +8,10 @@ from .type_def import FrozenKeys
 
 
 # Create a generic variable that can be 'AbstractMeta', or any subclass.
-M = TypeVar('M', bound='AbstractMeta')
-# Use `Type` here explicitly, because we will never have an `M` object.
-M = Type[M]
-META = M  # alias, since `M` is already defined in another module
+# Full word as `M` is already defined in another module
+META_ = TypeVar('META_', bound='AbstractMeta')
+# Use `Type` here explicitly, because we will never have an `META_` object.
+META = Type[META_]
 
 
 class ABCOrAndMeta(ABCMeta):
@@ -24,7 +24,7 @@ class ABCOrAndMeta(ABCMeta):
       - https://stackoverflow.com/a/57351066/10237506
     """
 
-    def __or__(cls: M, other: M) -> M:
+    def __or__(cls: META, other: META) -> META:
         """
         Merge two Meta configs. Priority will be given to the source config
         present in `cls`, e.g. the first operand in the '|' expression.
@@ -73,7 +73,7 @@ class ABCOrAndMeta(ABCMeta):
         # noinspection PyTypeChecker
         return type(new_cls_name, (src, ), base_dict)
 
-    def __and__(cls: M, other: M) -> M:
+    def __and__(cls: META, other: META) -> META:
         """
         Merge the `other` Meta config into the first one, i.e. `cls`. This
         operation does not create a new class, but instead it modifies the

--- a/dataclass_wizard/bases_meta.py
+++ b/dataclass_wizard/bases_meta.py
@@ -8,7 +8,7 @@ from datetime import datetime, date
 from typing import Type, Optional, Dict, Union
 
 from .abstractions import AbstractJSONWizard
-from .bases import AbstractMeta, M
+from .bases import AbstractMeta, META
 from .class_helper import (
     _META_INITIALIZER, _META,
     get_outer_class_name, get_class_name, create_new_class,
@@ -176,7 +176,7 @@ def LoadMeta(*, debug_enabled: bool = False,
              raise_on_unknown_json_key: bool = False,
              json_key_to_field: Dict[str, str] = None,
              key_transform: Union[LetterCase, str] = None,
-             tag: str = None) -> M:
+             tag: str = None) -> META:
     """
     Helper function to setup the ``Meta`` Config for the JSON load
     (de-serialization) process, which is intended for use alongside the
@@ -216,7 +216,7 @@ def DumpMeta(*, debug_enabled: bool = False,
              marshal_date_time_as: Union[DateTimeTo, str] = None,
              key_transform: Union[LetterCase, str] = None,
              tag: str = None,
-             skip_defaults: bool = False) -> M:
+             skip_defaults: bool = False) -> META:
     """
     Helper function to setup the ``Meta`` Config for the JSON dump
     (serialization) process, which is intended for use alongside the

--- a/dataclass_wizard/class_helper.py
+++ b/dataclass_wizard/class_helper.py
@@ -14,7 +14,7 @@ from .utils.typing_compat import (
 
 # A cached mapping of dataclass to the list of fields, as returned by
 # `dataclasses.fields()`.
-_FIELDS: Dict[Type, Tuple[Field]] = {}
+_FIELDS: Dict[Type, Tuple[Field, ...]] = {}
 
 # Mapping of main dataclass to its `load` function.
 _CLASS_TO_LOAD_FUNC: Dict[Type, Any] = {}
@@ -276,7 +276,7 @@ def get_meta(cls: Type) -> META:
     return _META.get(cls, AbstractMeta)
 
 
-def dataclass_fields(cls) -> Tuple[Field]:
+def dataclass_fields(cls) -> Tuple[Field, ...]:
     """
     Cache the `dataclasses.fields()` call for each class, as overall that
     ends up around 5x faster than making a fresh call each time.
@@ -288,7 +288,7 @@ def dataclass_fields(cls) -> Tuple[Field]:
     return _FIELDS[cls]
 
 
-def dataclass_init_fields(cls) -> Tuple[Field]:
+def dataclass_init_fields(cls) -> Tuple[Field, ...]:
     """Get only the dataclass fields that would be passed into the constructor."""
     return tuple(f for f in dataclass_fields(cls) if f.init)
 

--- a/dataclass_wizard/class_helper.py
+++ b/dataclass_wizard/class_helper.py
@@ -3,7 +3,7 @@ from dataclasses import MISSING, Field, fields
 from typing import Dict, Tuple, Type, Union, Callable, Optional, Any
 
 from .abstractions import W, AbstractLoader, AbstractDumper, AbstractParser
-from .bases import M, AbstractMeta
+from .bases import AbstractMeta, META
 from .models import JSONField, JSON, Extras, _PatternedDT
 from .type_def import ExplicitNull, ExplicitNullType, T
 from .utils.dict_helper import DictWithLowerStore
@@ -56,7 +56,7 @@ _META_INITIALIZER: Dict[
 
 # Mapping of dataclass to its Meta inner class, which will only be set when
 # the :class:`JSONSerializable.Meta` is sub-classed.
-_META: Dict[Type, M] = {}
+_META: Dict[Type, META] = {}
 
 
 def dataclass_to_loader(cls):
@@ -111,7 +111,7 @@ def dataclass_field_to_json_field(cls):
 def dataclass_field_to_load_parser(
         cls_loader: Type[AbstractLoader],
         cls: Type,
-        config: M,
+        config: META,
         save: bool = True) -> 'DictWithLowerStore[str, AbstractParser]':
     """
     Returns a mapping of each lower-cased field name to its annotated type.
@@ -124,7 +124,7 @@ def dataclass_field_to_load_parser(
 
 def _setup_load_config_for_cls(cls_loader: Type[AbstractLoader],
                                cls: Type,
-                               config: M,
+                               config: META,
                                save: bool = True
                                ) -> 'DictWithLowerStore[str, AbstractParser]':
     """
@@ -267,7 +267,7 @@ def call_meta_initializer_if_needed(cls: Type[W]):
         _META_INITIALIZER[cls_name](cls)
 
 
-def get_meta(cls: Type) -> M:
+def get_meta(cls: Type) -> META:
     """
     Retrieves the Meta config for the :class:`AbstractJSONWizard` subclass.
 

--- a/dataclass_wizard/errors.py
+++ b/dataclass_wizard/errors.py
@@ -41,7 +41,7 @@ class ParseError(JSONWizardError):
 
     def __init__(self, base_err: Exception,
                  obj: Any,
-                 ann_type: Union[Type, Iterable],
+                 ann_type: Optional[Union[Type, Iterable]],
                  _default_class: Optional[type] = None,
                  _field_name: Optional[str] = None,
                  _json_object: Any = None,

--- a/dataclass_wizard/models.py
+++ b/dataclass_wizard/models.py
@@ -3,7 +3,7 @@ import json
 from dataclasses import MISSING, Field, _create_fn
 from datetime import date, datetime, time
 from typing import (cast, Collection, Callable,
-                    Optional, List, Union, Type)
+                    Optional, List, Union, Type, Generic)
 
 from .bases import META
 from .constants import PY310_OR_ABOVE
@@ -14,9 +14,6 @@ from .utils.type_conv import as_datetime, as_time, as_date
 
 # Type for a string or a collection of strings.
 _STR_COLLECTION = Union[str, Collection[str]]
-
-# A date, time, datetime sub type, or None.
-DT_OR_NONE = Optional[DT]
 
 
 class Extras(PyTypedDict):
@@ -205,7 +202,7 @@ class DateTimePattern(datetime, _PatternBase):
     __slots__ = ()
 
 
-class _PatternedDT:
+class _PatternedDT(Generic[DT]):
     """
     Base class for pattern matching using :meth:`datetime.strptime` when
     loading (de-serializing) a string to a date / time / datetime object.
@@ -216,8 +213,8 @@ class _PatternedDT:
     __slots__ = ('cls',
                  'pattern')
 
-    def __init__(self, pattern: str, cls: DT_OR_NONE = None):
-        self.cls = cls
+    def __init__(self, pattern: str, cls: Optional[Type[DT]] = None):
+        self.cls: Optional[Type[DT]] = cls
         self.pattern = pattern
 
     def get_transform_func(self) -> Callable[[str], DT]:

--- a/dataclass_wizard/type_def.py
+++ b/dataclass_wizard/type_def.py
@@ -72,7 +72,7 @@ DT = TypeVar('DT', date, time, datetime)
 DD = TypeVar('DD', bound=DefaultDict)
 
 # Numeric type
-N = TypeVar('N', int, float, complex)
+N = Union[int, float]
 
 # Sequence type
 S = TypeVar('S', bound=Sequence)

--- a/dataclass_wizard/type_def.py
+++ b/dataclass_wizard/type_def.py
@@ -52,6 +52,7 @@ NUMBERS = int, float
 
 # Generic type
 T = TypeVar('T')
+TT = TypeVar('TT')
 
 # Enum subclass type
 E = TypeVar('E', bound=Enum)

--- a/dataclass_wizard/utils/typing_compat.py
+++ b/dataclass_wizard/utils/typing_compat.py
@@ -376,7 +376,7 @@ def eval_forward_ref(base_type: FREF,
     return typing._eval_type(base_type, base_globals, _TYPING_LOCALS)
 
 
-def eval_forward_ref_if_needed(base_type: FREF,
+def eval_forward_ref_if_needed(base_type: typing.Union[typing.Type, FREF],
                                base_cls: typing.Type):
     """
     If needed, evaluate a forward reference using the class globals, and

--- a/tests/unit/test_bases_meta.py
+++ b/tests/unit/test_bases_meta.py
@@ -8,7 +8,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from dataclass_wizard import JSONWizard
-from dataclass_wizard.bases import M
+from dataclass_wizard.bases import META
 from dataclass_wizard.bases_meta import BaseJSONWizardMeta
 from dataclass_wizard.enums import LetterCase, DateTimeTo
 from dataclass_wizard.errors import ParseError
@@ -56,7 +56,7 @@ def test_merge_meta_with_or():
         json_key_to_field = {'k2': 'v2'}
 
     # Merge the two Meta config together
-    merged_meta: M = A | B
+    merged_meta: META = A | B
 
     # Assert we are a subclass of A, which subclasses from `BaseJSONWizardMeta`
     assert issubclass(merged_meta, BaseJSONWizardMeta)
@@ -99,7 +99,7 @@ def test_merge_meta_with_and():
         json_key_to_field = {'k2': 'v2'}
 
     # Merge the two Meta config together
-    merged_meta: M = A & B
+    merged_meta: META = A & B
 
     # Assert we are a subclass of A, which subclasses from `BaseJSONWizardMeta`
     assert issubclass(merged_meta, BaseJSONWizardMeta)


### PR DESCRIPTION
#51 
I've look around the type errors that mypy found. Unfortunately it's harder than I thought - some of them are caused by the fact that some code is valid in dynamic context, but making it understandable by mypy is not trivial. Another group will require some changes in code. Yet another group of errors might probably be fixed by using `TypeGuard`s, but this is a new feature from  python3.10. 

In this PR I fix almost all errors in `parsers.py` file. There is one left and fixing it will probably require more changes in code (Liskov principle is broken there, I described it more in the commit message).

More errors arise after the change, but as far as my changes make sense, they are caused by mypy having more data to analyze.

I attach mypy output before and after the changes and the diff between them. Checked on project virtualenv with python3.8, all test are passing.
[mypy_diff.txt](https://github.com/rnag/dataclass-wizard/files/9154014/mypy_diff.txt)
[mypy_new.txt](https://github.com/rnag/dataclass-wizard/files/9154015/mypy_new.txt)
[mypy_old.txt](https://github.com/rnag/dataclass-wizard/files/9142979/mypy_old.txt)
 