### PR TITLE
Register and process yaml tags when tags are set

### DIFF
--- a/tests/unit/test_wizard_mixins.py
+++ b/tests/unit/test_wizard_mixins.py
@@ -26,7 +26,7 @@ class MyYAMLWizard(YAMLWizard):
 
 
 @dataclass
-class Inner:
+class Inner(YAMLWizard):
     my_float: float
     my_list: List[str]
 
@@ -76,13 +76,13 @@ def test_json_file_wizard_methods(mocker: MockerFixture, mock_open):
 
 def test_yaml_wizard_methods(mocker: MockerFixture):
     """Test and coverage the base methods in YAMLWizard."""
-    yaml_data = """\
+    yaml_data = """
     my_str: test value
     inner:
         my_float: 1.2
         my_list:
             - hello, world!
-            - 123\
+            - 123
     """
 
     # Patch open() to return a file-like object which returns our string data.


### PR DESCRIPTION
Hi

I just went through the mildly painful process of trying to input data that includes local tags i.e. `!TagName`.

Anyway the way that `dataclass_wizard` handles the loading and dumping of such types is unfortunately not compatible with something like [serde_yaml](https://docs.rs/serde_yaml/latest/serde_yaml/).

I adjusted `__init_subclass__` to register custom loaders on `yaml.SafeLoader` and custom representers on `yaml.SafeDumper` to handle these cases. Obviously this is not quite clean, because these adjustments are now needed for the serialization and the encoder and decoder arguments should not be exposed in this case.

Also with this change attributes that are local class instances need these classes to be subclasses of `YAMLWizard`

It works for me. I will use it on my fork. If you want to adjust this to cleanly implement this into the meta class madness consider this a feature request.

Cheers

P.S. Thanks for maintaining this library! i use it a lot. and love it. <3