### PR TITLE
feat: allow no key transformations

### DIFF
--- a/dataclass_wizard/enums.py
+++ b/dataclass_wizard/enums.py
@@ -29,7 +29,7 @@ class LetterCase(Enum):
     SNAKE = FuncWrapper(to_snake_case)
     # Perfoms no conversion on strings.
     #   ex: `MY_FIELD_NAME` -> `MY_FIELD_NAME`
-    NONE = FuncWrapper(str)
+    NONE = FuncWrapper(lambda s: s)
 
     def __call__(self, *args):
         return self.value.f(*args)

--- a/dataclass_wizard/enums.py
+++ b/dataclass_wizard/enums.py
@@ -27,6 +27,9 @@ class LetterCase(Enum):
     # Converts strings (generally in camel case) to snake case.
     #   ex: `myFieldName` -> `my_field_name`
     SNAKE = FuncWrapper(to_snake_case)
+    # Perfoms no conversion on strings.
+    #   ex: `MY_FIELD_NAME` -> `MY_FIELD_NAME`
+    NONE = FuncWrapper(str)
 
     def __call__(self, *args):
         return self.value.f(*args)


### PR DESCRIPTION
Allows the ability to define keys in JSON/dataclass that do not undergo transformation.

```python
@dataclass
class MyDataclass(JSONWizard):
    VAR_1: int
    vAr__2: int
    VAr3__: int

    class _(JSONWizard.Meta):
        key_transform_with_dump = "NONE"

data = """{
    "VAR_1": 1,
    "vAr__2": 2,
    "VAr3__": 3
}
"""

foo = MyDataclass.from_json(data)
print("JSON -> Dataclass", foo)
print("Dataclass -> JSON", foo.to_json())
```

prints with no transformations

```
JSON -> Dataclass {
  "VAR_1": 1,
  "vAr__2": 2,
  "VAr3__": 3
}
Dataclass -> JSON {"VAR_1": 1, "vAr__2": 2, "VAr3__": 3}
```