### PR TITLE
Allow variadic tuples of length 0. Fixes #104

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+# File created by pytest
+testing.json

--- a/dataclass_wizard/parsers.py
+++ b/dataclass_wizard/parsers.py
@@ -401,10 +401,7 @@ class VariadicTupleParser(TupleParser):
         # Total count should be `Infinity` here, since the variadic form
         # accepts any number of possible arguments.
         self.total_count: N = float('inf')
-        # Check for the count of parsers which don't handle `NoneType` - this
-        # should exclude the parsers for `Union` types that have `None` in the
-        # list of args.
-        self.required_count = 0 if None in self.first_elem_parser[0] else 1
+        self.required_count = 0
 
     def __call__(self, o: M) -> M:
         """

--- a/tests/unit/test_load.py
+++ b/tests/unit/test_load.py
@@ -1151,6 +1151,8 @@ def test_tuple_without_type_hinting(input, expectation, expected):
             # behavior later if needed.
             [{}], does_not_raise(), (0, )),
         (
+            [], does_not_raise(), tuple()),
+        (
             [True, False, True], pytest.raises(TypeError), None),
         (
             # Raises a `ValueError` because `hello` cannot be converted to int


### PR DESCRIPTION
With this patch, the following code works:
```
from dataclasses import dataclass
from dataclass_wizard import fromdict
@dataclass
class Test:
    my_ints: tuple[int, ...]


fromdict(Test, {"my_ints": []})
```

I am not sure why the required count should ever not be zero, based on my understanding of the code? If you have `...` it means zero or more, not one or more.

The new unit test I added failed before this patch, and succeeds afterwards. None of the existing tests fail, so maybe this is a safe fix? Otherwise could you please expand on the logic & we can figure out the appropriate solution.

Fixes #104 