### PR TITLE
Fix: LiteralParser __contains__ method compares value of item with Literal arguments

### DIFF
--- a/dataclass_wizard/parsers.py
+++ b/dataclass_wizard/parsers.py
@@ -84,6 +84,14 @@ class LiteralParser(AbstractParser):
             val: type(val) for val in get_args(self.base_type)
         }
 
+    def __contains__(self, item) -> bool:
+        """
+        Return true if the LiteralParser is expected to handle the specified item
+        type. Checks that the item is incorporated in the given expected values of
+        the Literal.
+        """
+        return item in self.value_to_type.keys()
+
     def __call__(self, o: Any):
         """
         Checks for Literal equivalence, as mentioned here:

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -1,0 +1,17 @@
+from typing import Literal
+
+import pytest
+
+from dataclass_wizard.parsers import LiteralParser
+
+
+class TestLiteralParser:
+    @pytest.fixture
+    def literal_parser(self) -> LiteralParser:
+        return LiteralParser(cls=object, base_type=Literal["foo"], extras={})
+
+    def test_literal_parser_dunder_contains_succeeds_if_item_in_keys_of_base_type(self, literal_parser):
+        assert "foo" in literal_parser
+
+    def test_literal_parser_dunder_contains_fails_if_item_not_in_keys_of_base_type(self, literal_parser):
+        assert "bar" not in literal_parser


### PR DESCRIPTION
Closes #67.

Instead of checking that `type(item)` is `self.base_type` (like is implemented in the base class `AbstractParser`), we need to check if the `item` is in the values of the given `Literal`.