### PR TITLE
Add `py.typed` marker

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
 include README.rst
+include dataclass_wizard/py.typed
 
 recursive-include tests *.py
 recursive-exclude tests/integration *

--- a/dataclass_wizard/py.typed
+++ b/dataclass_wizard/py.typed
@@ -1,0 +1,1 @@
+# PEP-561 marker https://mypy.readthedocs.io/en/latest/installed_packages.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,5 +13,9 @@ universal = 1
 [flake8]
 exclude = docs
 
+[options.package_data]
+# If any package or subpackage contains *.txt, *.rst, *.md, or py.typed files, include them:
+* = *.txt, *.rst, *.md, py.typed
+
 [tool:pytest]
 collect_ignore = ['setup.py']


### PR DESCRIPTION
Fixes https://github.com/rnag/dataclass-wizard/issues/51
Finalizes https://github.com/rnag/dataclass-wizard/issues/51

"Recent python versions" (i.e. tested with now-EOL 3.8) do NOT need any of the extra directives to include the `py.typed` marker.

But Python 3.6 (maybe `wheel==0.37.1`?) does.

Signed-off-by: Stavros Ntentos <11300730-stavros-relex@users.noreply.gitlab.com>