### PR TITLE
Support cyclic references

### DIFF
--- a/dataclass_wizard/bases.py
+++ b/dataclass_wizard/bases.py
@@ -134,6 +134,12 @@ class AbstractMeta(metaclass=ABCOrAndMeta):
     # apply in a recursive manner.
     recursive: ClassVar[bool] = True
 
+    # True to support cyclic or self-referential dataclasses. For example,
+    # the type of a dataclass field in class `A` refers to `A` itself.
+    #
+    # See https://github.com/rnag/dataclass-wizard/issues/62 for more details.
+    recursive_classes: ClassVar[bool] = False
+
     # True to raise an class:`UnknownJSONKey` when an unmapped JSON key is
     # encountered when `from_dict` or `from_json` is called; an unknown key is
     # one that does not have a known mapping to a dataclass field.

--- a/dataclass_wizard/bases_meta.py
+++ b/dataclass_wizard/bases_meta.py
@@ -14,6 +14,7 @@ from .class_helper import (
     get_outer_class_name, get_class_name, create_new_class,
     json_field_to_dataclass_field, dataclass_field_to_json_field
 )
+from .constants import TAG
 from .decorators import try_with_load
 from .dumpers import get_dumper
 from .enums import LetterCase, DateTimeTo
@@ -173,10 +174,13 @@ class BaseJSONWizardMeta(AbstractMeta):
 # noinspection PyPep8Naming
 def LoadMeta(*, debug_enabled: bool = False,
              recursive: bool = True,
+             recursive_classes: bool = False,
              raise_on_unknown_json_key: bool = False,
              json_key_to_field: Dict[str, str] = None,
              key_transform: Union[LetterCase, str] = None,
-             tag: str = None) -> META:
+             tag: str = None,
+             tag_key: str = TAG,
+             auto_assign_tags: bool = False) -> META:
     """
     Helper function to setup the ``Meta`` Config for the JSON load
     (de-serialization) process, which is intended for use alongside the
@@ -198,11 +202,14 @@ def LoadMeta(*, debug_enabled: bool = False,
     base_dict = {
         '__slots__': (),
         'raise_on_unknown_json_key': raise_on_unknown_json_key,
+        'recursive_classes': recursive_classes,
         'key_transform_with_load': key_transform,
         'json_key_to_field': json_key_to_field,
         'debug_enabled': debug_enabled,
         'recursive': recursive,
         'tag': tag,
+        'tag_key': tag_key,
+        'auto_assign_tags': auto_assign_tags,
     }
 
     # Create a new subclass of :class:`AbstractMeta`

--- a/dataclass_wizard/errors.py
+++ b/dataclass_wizard/errors.py
@@ -266,3 +266,33 @@ class MissingData(ParseError):
             msg = f'{msg}{sep}{parts}'
 
         return msg
+
+
+class RecursiveClassError(JSONWizardError):
+    """
+    Error raised when we encounter a `RecursionError` due to cyclic
+    or self-referential dataclasses.
+    """
+
+    _TEMPLATE = ('Failure parsing class `{cls}`. '
+                 'Consider updating the Meta config to enable '
+                 'the `recursive_classes` flag.\n\n'
+                 'Example with `dataclass_wizard.LoadMeta`:\n'
+                 ' >>> LoadMeta(recursive_classes=True).bind_to({cls})\n\n'
+                 'For more info, please see:\n'
+                 '  https://github.com/rnag/dataclass-wizard/issues/62')
+
+    def __init__(self, cls: Type):
+        super().__init__()
+
+        self.class_name: str = self.name(cls)
+
+    # TODO: update to use `type_name` once changes are merged
+    @staticmethod
+    def name(obj) -> str:
+        """Return the type or class name of an object"""
+        return getattr(obj, '__qualname__', getattr(obj, '__name__', obj))
+
+    @property
+    def message(self) -> str:
+        return self._TEMPLATE.format(cls=self.class_name)

--- a/dataclass_wizard/loaders.py
+++ b/dataclass_wizard/loaders.py
@@ -607,7 +607,11 @@ def load_func_for_dataclass(
     try:
         field_to_parser = dataclass_field_to_load_parser(cls_loader, cls, config)
     except RecursionError as e:
-        raise RecursiveClassError(cls) from None
+        if meta.recursive_classes:
+            # recursion-safe loader is already in use; something else must have gone wrong
+            raise
+        else:
+            raise RecursiveClassError(cls) from None
 
     # A cached mapping of each key in a JSON or dictionary object to the
     # resolved dataclass field name; useful so we don't need to do a case

--- a/dataclass_wizard/loaders.py
+++ b/dataclass_wizard/loaders.py
@@ -20,7 +20,8 @@ from .class_helper import (
 )
 from .constants import _LOAD_HOOKS, SINGLE_ARG_ALIAS, IDENTITY
 from .decorators import _alias, _single_arg_alias, resolve_alias_func, _identity
-from .errors import ParseError, MissingFields, UnknownJSONKey, MissingData
+from .errors import (ParseError, MissingFields, UnknownJSONKey,
+                     MissingData, RecursiveClassError)
 from .log import LOG
 from .models import Extras, _PatternedDT
 from .parsers import *
@@ -606,11 +607,7 @@ def load_func_for_dataclass(
     try:
         field_to_parser = dataclass_field_to_load_parser(cls_loader, cls, config)
     except RecursionError as e:
-        msg = (f'Update the Meta config for `{cls.__qualname__}` to enable '
-               f'`recursive_classes` flag')
-
-        # TODO
-        raise ParseError(e, None, None, _default_class=cls, resolution=msg) from None
+        raise RecursiveClassError(cls) from None
 
     # A cached mapping of each key in a JSON or dictionary object to the
     # resolved dataclass field name; useful so we don't need to do a case

--- a/dataclass_wizard/parsers.py
+++ b/dataclass_wizard/parsers.py
@@ -37,6 +37,7 @@ from .utils.typing_compat import (
 
 # Type defs
 GetParserType = Callable[[Type[T], Type, Extras], AbstractParser]
+LoadHookType = Callable[[Any], T]
 TupleOfParsers = Tuple[AbstractParser, ...]
 
 
@@ -52,7 +53,7 @@ class IdentityParser(AbstractParser[Type[T], T]):
 class SingleArgParser(AbstractParser[Type[T], T]):
     __slots__ = ('hook', )
 
-    hook: Callable[[Any], T]
+    hook: LoadHookType
 
     # noinspection PyDataclass
     def __post_init__(self, *_):
@@ -89,9 +90,9 @@ class RecursionSafeParser(AbstractParser):
     __slots__ = ('extras', 'hook')
 
     extras: Extras
-    hook: Optional[Callable]
+    hook: Optional[LoadHookType]
 
-    def load_hook_func(self) -> Callable[[Any], T]:
+    def load_hook_func(self) -> LoadHookType:
         from .loaders import load_func_for_dataclass
 
         return load_func_for_dataclass(


### PR DESCRIPTION
Rebased old branch https://github.com/rnag/dataclass-wizard/tree/WIP-support-cyclic-references (from #62) onto `main`

Added 22060e67bd20312cf154f98a448198831681a023 to ensure that `RecursiveClassError` isn't shown in misleading cases.