### PR TITLE
v0.27.0: Drop support for Python Versions 3.6, 3.7, and 3.8

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -18,7 +18,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        python-versions: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
+        python-versions: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-20.04]
         # Uncomment if I need to run it on other environments too (currently
         # there's not a huge need)

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -18,7 +18,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        python-versions: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12', '3.13']
+        python-versions: [3.9, '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-20.04]
         # Uncomment if I need to run it on other environments too (currently
         # there's not a huge need)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        python-versions: [3.8]
+        python-versions: [3.11]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -107,7 +107,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12 and 3.13, and for PyPy. Check
+3. The pull request should work for Python 3.9, 3.10, 3.11, 3.12 and 3.13, and for PyPy. Check
    https://github.com/rnag/dataclass-wizard/actions/workflows/dev.yml
    and make sure that the tests pass for all supported Python versions.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -107,7 +107,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.6, 3.7, 3.8, 3.9, 3.10, 3.11 and 3.12, and for PyPy. Check
+3. The pull request should work for Python 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12 and 3.13, and for PyPy. Check
    https://github.com/rnag/dataclass-wizard/actions/workflows/dev.yml
    and make sure that the tests pass for all supported Python versions.
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,23 @@
 History
 =======
 
+0.26.0 (2024-11-05)
+-------------------
+
+* This will be the latest (minor) release with support for Python 3.6, 3.7, and 3.8 --
+  all of which have reached *end-of-life*!
+
+**Features and Improvements**
+
+* Add compatability and support for **Python 3.13**. Thanks to :user:`benjjs` in :pr:`129`!
+
+**Bugfixes**
+
+* Fix: :meth:`LiteralParser.__contains__` method compares value of item with `Literal`_ arguments.
+  Contributed by :user:`mikeweltevrede` in :pr:`111`.
+
+.. _Literal: https://docs.python.org/3/library/typing.html#typing.Literal
+
 0.25.0 (2024-11-03)
 -------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,28 @@
 History
 =======
 
+0.27.0 (2024-11-09)
+-------------------
+
+**Features and Improvements**
+
+* This minor release drops support/compatibility for Python 3.6, 3.7, and 3.8 -- all of
+  which have reached End of Life (EOL). Check out the `Python End of Life Cycle here`_.
+  Side effects and results of this changes include:
+    * Fix `pyup` errors - currently pyup shows as "insecure" since we're forced into using old or outdated
+      pkg versions since most don't support Python 3.8 or earlier.
+    * Clean up most if not all `TODO`s scattered in code in library, since most of those are python version- specific anyway.
+    * More cleaner, easier to maintain codebase.
+* `Add test case`_ to satisfy :issue:`89`.
+* Add support for cyclic or "recursive" dataclasses, first mentioned in :issue:`62` (thanks to :user:`dlenski` in :pr:`138` for finalizing this!)
+
+**Bugfixes**
+
+* :issue:`62`: Cyclic or "recursive" dataclasses no longer raises a :class:`RecursionError`.
+
+.. _Python End of Life Cycle here: https://devguide.python.org/versions/#status-of-python-versions
+.. _Add test case: https://github.com/rnag/dataclass-wizard/pull/139/commits/cf2e98cb75c75dc3e566ed0205637dbd4632e159
+
 0.26.1 (2024-11-09)
 -------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,27 +2,29 @@
 History
 =======
 
-0.27.0 (2024-11-09)
+0.27.0 (2024-11-10)
 -------------------
 
 **Features and Improvements**
 
-* This minor release drops support/compatibility for Python 3.6, 3.7, and 3.8 -- all of
-  which have reached End of Life (EOL). Check out the `Python End of Life Cycle here`_.
-  Side effects and results of this changes include:
-    * Fix `pyup` errors - currently pyup shows as "insecure" since we're forced into using old or outdated
-      pkg versions since most don't support Python 3.8 or earlier.
-    * Clean up most if not all `TODO`s scattered in code in library, since most of those are python version- specific anyway.
-    * More cleaner, easier to maintain codebase.
-* `Add test case`_ to satisfy :issue:`89`.
-* Add support for cyclic or "recursive" dataclasses, first mentioned in :issue:`62` (thanks to :user:`dlenski` in :pr:`138` for finalizing this!)
+* This minor release drops support for Python 3.6, 3.7, and 3.8, all of which have reached End of Life (EOL). Check out the Python End of Life Cycle here_. Key changes resulting from this update include:
+    * Resolved pyup errors, previously flagged as "insecure" due to outdated package versions that lacked support for Python 3.8 or earlier.
+    * Update all requirements to latest versions.
+    * Cleaned up various TODO comments scattered throughout the codebase, as many were specific to older Python versions.
+    * Simplified and improved codebase for easier maintenance.
+    * Remove everything except the ``py.typed`` file (see comment_).
+* Added `test case`_ to satisfy :issue:`89`.
+* Added support for cyclic or "recursive" dataclasses, as first mentioned in :issue:`62` (special thanks to :user:`dlenski` for finalizing this in :pr:`138`!).
 
 **Bugfixes**
 
 * :issue:`62`: Cyclic or "recursive" dataclasses no longer raises a :class:`RecursionError`.
+* Typing locals should now correctly key off the correct Python version, see the commit_ that addressed this.
 
-.. _Python End of Life Cycle here: https://devguide.python.org/versions/#status-of-python-versions
-.. _Add test case: https://github.com/rnag/dataclass-wizard/pull/139/commits/cf2e98cb75c75dc3e566ed0205637dbd4632e159
+.. _here: https://devguide.python.org/versions/#status-of-python-versions
+.. _test case: https://github.com/rnag/dataclass-wizard/pull/139/commits/cf2e98cb75c75dc3e566ed0205637dbd4632e159
+.. _comment: https://github.com/rnag/dataclass-wizard/pull/136#issuecomment-2466463153
+.. _commit: https://github.com/rnag/dataclass-wizard/pull/139/commits/310a0c28690fdfdf15a386a427d1ea9aaf8898a1
 
 0.26.1 (2024-11-09)
 -------------------

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,6 @@ include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
 include README.rst
-include dataclass_wizard/py.typed
 
 recursive-include tests *.py
 recursive-exclude tests/integration *

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ clean-build: ## remove build artifacts
 	rm -fr dist/
 	rm -fr .eggs/
 	find . -name '*.egg-info' -exec rm -fr {} +
-	find . -name '*.egg' -exec rm -f {} +
+	find . -name '*.egg' -type f -exec rm -f {} +
 
 clean-pyc: ## remove Python file artifacts
 	find . -name '*.pyc' -exec rm -f {} +

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ Alternatively, this library is available `on conda`_ under the `conda-forge`_ ch
 
     $ conda install dataclass-wizard -c conda-forge
 
-The ``dataclass-wizard`` library officially supports **Python 3.6** or higher.
+The ``dataclass-wizard`` library officially supports **Python 3.9** or higher.
 
 .. _on conda: https://anaconda.org/conda-forge/dataclass-wizard
 .. _conda-forge: https://conda-forge.org/
@@ -133,7 +133,7 @@ Usage and Examples
 
 Using the built-in JSON marshalling support for dataclasses:
 
-    Note: The following example should work in **Python 3.7+** with the included ``__future__``
+    Note: The following example should work in **Python 3.9+** with the included ``__future__``
     import.
 
 .. code:: python3
@@ -633,9 +633,7 @@ A brief example of the intended usage is shown below:
 
     from dataclasses import dataclass
     from datetime import time, datetime
-    from typing import List
-    # Note: in Python 3.9+, you can import this from `typing` instead
-    from typing_extensions import Annotated
+    from typing import Annotated, List
 
     from dataclass_wizard import fromdict, asdict, DatePattern, TimePattern, Pattern
 

--- a/README.rst
+++ b/README.rst
@@ -633,7 +633,7 @@ A brief example of the intended usage is shown below:
 
     from dataclasses import dataclass
     from datetime import time, datetime
-    from typing import Annotated, List
+    from typing import Annotated
 
     from dataclass_wizard import fromdict, asdict, DatePattern, TimePattern, Pattern
 
@@ -643,7 +643,7 @@ A brief example of the intended usage is shown below:
         date_field: DatePattern['%m-%Y']
         dt_field: Annotated[datetime, Pattern('%m/%d/%y %H.%M.%S')]
         time_field1: TimePattern['%H:%M']
-        time_field2: Annotated[List[time], Pattern('%I:%M %p')]
+        time_field2: Annotated[list[time], Pattern('%I:%M %p')]
 
 
     data = {'date_field': '12-2022',
@@ -831,7 +831,6 @@ result. An example of both these approaches is shown below.
 
     from collections import defaultdict
     from dataclasses import field, dataclass
-    from typing import DefaultDict, List
 
     from dataclass_wizard import JSONWizard
 
@@ -845,8 +844,8 @@ result. An example of both these approaches is shown below.
         my_str: str
         other_str: str = 'any value'
         optional_str: str = None
-        my_list: List[str] = field(default_factory=list)
-        my_dict: DefaultDict[str, List[float]] = field(
+        my_list: list[str] = field(default_factory=list)
+        my_dict: defaultdict[str, list[float]] = field(
             default_factory=lambda: defaultdict(list))
 
 

--- a/dataclass_wizard/__init__.py
+++ b/dataclass_wizard/__init__.py
@@ -9,7 +9,7 @@ Sample Usage:
 
     >>> from dataclasses import dataclass, field
     >>> from datetime import datetime
-    >>> from typing import Optional, List
+    >>> from typing import Optional
     >>>
     >>> from dataclass_wizard import JSONSerializable, property_wizard
     >>>
@@ -18,7 +18,7 @@ Sample Usage:
     >>> class MyClass(JSONSerializable, metaclass=property_wizard):
     >>>
     >>>     my_str: Optional[str]
-    >>>     list_of_int: List[int] = field(default_factory=list)
+    >>>     list_of_int: list[int] = field(default_factory=list)
     >>>     # You can also define this as `my_dt`, however only the annotation
     >>>     # will carry over in that case, since the value is re-declared by
     >>>     # the property below.

--- a/dataclass_wizard/__init__.py
+++ b/dataclass_wizard/__init__.py
@@ -98,7 +98,6 @@ __all__ = [
 import logging
 
 from .bases_meta import LoadMeta, DumpMeta
-from .constants import PY36
 from .dumpers import DumpMixin, setup_default_dumper, asdict
 from .loaders import LoadMixin, setup_default_loader, fromlist, fromdict
 from .models import (json_field, json_key, Container,
@@ -122,10 +121,3 @@ setup_default_loader()
 # Setup the default type hooks to use when converting `dataclass` instances to
 # a JSON `string` or a Python `dict` object.
 setup_default_dumper()
-
-if PY36:    # pragma: no cover
-    # Python 3.6 requires a backport for `datetime.fromisoformat()`
-    # noinspection PyPackageRequirements
-    # noinspection PyUnresolvedReferences
-    from backports.datetime_fromisoformat import MonkeyPatch
-    MonkeyPatch.patch_fromisoformat()

--- a/dataclass_wizard/__version__.py
+++ b/dataclass_wizard/__version__.py
@@ -7,7 +7,7 @@ __description__ = 'Marshal dataclasses to/from JSON. Use field properties ' \
                   'with initial values. Construct a dataclass schema with ' \
                   'JSON input.'
 __url__ = 'https://github.com/rnag/dataclass-wizard'
-__version__ = '0.25.0'
+__version__ = '0.26.0'
 __author__ = 'Ritvik Nag'
 __author_email__ = 'rv.kvetch@gmail.com'
 __license__ = 'Apache 2.0'

--- a/dataclass_wizard/class_helper.py
+++ b/dataclass_wizard/class_helper.py
@@ -30,10 +30,8 @@ _CLASS_TO_DUMPER: Dict[Type, Type[AbstractDumper]] = {}
 
 # A cached mapping of a dataclass to each of its case-insensitive field names
 # and load hook.
-#
-# Note: need to create a `ForwardRef` here, because Python 3.6 complains.
 _FIELD_NAME_TO_LOAD_PARSER: Dict[
-    Type, 'DictWithLowerStore[str, AbstractParser]'] = {}
+    Type, DictWithLowerStore[str, AbstractParser]] = {}
 
 # Since the dump process doesn't use Parsers currently, we use a sentinel
 # mapping to confirm if we need to setup the dump config for a dataclass

--- a/dataclass_wizard/constants.py
+++ b/dataclass_wizard/constants.py
@@ -8,18 +8,6 @@ LOG_LEVEL = os.getenv('WIZARD_LOG_LEVEL', 'ERROR').upper()
 # Current system Python version
 _PY_VERSION = sys.version_info[:2]
 
-# Check if currently running Python 3.6
-PY36 = _PY_VERSION == (3, 6)
-
-# Check if currently running Python 3.8
-PY38 = _PY_VERSION == (3, 8)
-
-# Check if currently running Python 3.8 or higher
-PY38_OR_ABOVE = _PY_VERSION >= (3, 8)
-
-# Check if currently running Python 3.9
-PY39 = _PY_VERSION == (3, 9)
-
 # Check if currently running Python 3.10 or higher
 PY310_OR_ABOVE = _PY_VERSION >= (3, 10)
 

--- a/dataclass_wizard/constants.py
+++ b/dataclass_wizard/constants.py
@@ -26,6 +26,9 @@ PY310_OR_ABOVE = _PY_VERSION >= (3, 10)
 # Check if currently running Python 3.11 or higher
 PY311_OR_ABOVE = _PY_VERSION >= (3, 11)
 
+# Check if currently running Python 3.13 or higher
+PY313_OR_ABOVE = _PY_VERSION >= (3, 13)
+
 # The name of the dictionary object that contains `load` hooks for each
 # object type. Also used to check if a class is a :class:`BaseLoadHook`
 _LOAD_HOOKS = '__LOAD_HOOKS__'

--- a/dataclass_wizard/decorators.py
+++ b/dataclass_wizard/decorators.py
@@ -148,13 +148,15 @@ def try_with_load_with_single_arg(original_fn: Callable,
     return new_func
 
 
-def discard_kwargs(f):
-
-    @wraps(f)
-    def new_func(*args, **_kwargs):
-        return f(*args)
-
-    return new_func
+# TODO Remove: Unused (was used for type_def`
+#  to support Python 3.8 or earlier)
+# def discard_kwargs(f):
+#
+#     @wraps(f)
+#     def new_func(*args, **_kwargs):
+#         return f(*args)
+#
+#     return new_func
 
 
 def _alias(default: Callable) -> Callable[[T], T]:

--- a/dataclass_wizard/decorators.py
+++ b/dataclass_wizard/decorators.py
@@ -148,17 +148,6 @@ def try_with_load_with_single_arg(original_fn: Callable,
     return new_func
 
 
-# TODO Remove: Unused (was used for type_def`
-#  to support Python 3.8 or earlier)
-# def discard_kwargs(f):
-#
-#     @wraps(f)
-#     def new_func(*args, **_kwargs):
-#         return f(*args)
-#
-#     return new_func
-
-
 def _alias(default: Callable) -> Callable[[T], T]:
     """
     Decorator which re-assigns a function `_f` to point to `default` instead.

--- a/dataclass_wizard/loaders.py
+++ b/dataclass_wizard/loaders.py
@@ -4,9 +4,11 @@ from datetime import datetime, time, date, timedelta
 from decimal import Decimal
 from enum import Enum
 from pathlib import Path
+# noinspection PyUnresolvedReferences,PyProtectedMember
 from typing import (
     Any, Type, Dict, List, Tuple, Iterable, Sequence, Union,
-    NamedTupleMeta, SupportsFloat, AnyStr, Text, Callable, Optional
+    NamedTupleMeta,
+    SupportsFloat, AnyStr, Text, Callable, Optional
 )
 from uuid import UUID
 

--- a/dataclass_wizard/models.py
+++ b/dataclass_wizard/models.py
@@ -1,6 +1,5 @@
 import json
-# noinspection PyProtectedMember
-from dataclasses import MISSING, Field, _create_fn
+from dataclasses import MISSING, Field
 from datetime import date, datetime, time
 from typing import (cast, Collection, Callable,
                     Optional, List, Union, Type, Generic)
@@ -9,6 +8,8 @@ from .bases import META
 from .constants import PY310_OR_ABOVE
 from .decorators import cached_property
 from .type_def import T, DT, Encoder, PyTypedDict, FileEncoder
+# noinspection PyProtectedMember
+from .utils.dataclass_compat import _create_fn
 from .utils.type_conv import as_datetime, as_time, as_date
 
 

--- a/dataclass_wizard/models.py
+++ b/dataclass_wizard/models.py
@@ -303,8 +303,6 @@ class _PatternedDT(Generic[DT]):
 
         locals_ns['default_load_func'] = default_load_func
 
-        # TODO This approach unfortunately won't work in Python 3.6. To fix
-        #   it, we'll need to pass `globals` instead of `locals` here.
         return _create_fn('pattern_to_dt',
                           ('date_string', ),
                           body_lines,
@@ -334,9 +332,8 @@ class Container(List[T]):
 
     """
 
-    # TODO: Uncomment once we drop support for Python 3.6
-    # __slots__ = ('__dict__',
-    #              '__orig_class__')
+    __slots__ = ('__dict__',
+                 '__orig_class__')
 
     @cached_property
     def __model__(self) -> Type[T]:

--- a/dataclass_wizard/parsers.py
+++ b/dataclass_wizard/parsers.py
@@ -84,6 +84,14 @@ class LiteralParser(AbstractParser[Type[M], M]):
             val: type(val) for val in get_args(self.base_type)
         }
 
+    def __contains__(self, item) -> bool:
+        """
+        Return true if the LiteralParser is expected to handle the specified item
+        type. Checks that the item is incorporated in the given expected values of
+        the Literal.
+        """
+        return item in self.value_to_type.keys()
+
     def __call__(self, o: Any) -> M:
         """
         Checks for Literal equivalence, as mentioned here:

--- a/dataclass_wizard/parsers.py
+++ b/dataclass_wizard/parsers.py
@@ -31,7 +31,7 @@ from .type_def import (
     T, M, S, DD, LSQ, N, NT, DT
 )
 from .utils.typing_compat import (
-    get_origin, get_args, get_named_tuple_field_types,
+    get_origin, get_args,
     get_keys_for_typed_dict, eval_forward_ref_if_needed)
 
 
@@ -482,9 +482,7 @@ class NamedTupleParser(AbstractParser[Type[NT], NT]):
                       get_parser: GetParserType):
 
         # Get the field annotations for the `NamedTuple` type
-        type_anns: Dict[str, Type[Any]] = get_named_tuple_field_types(
-            self.base_type
-        )
+        type_anns: Dict[str, Type[Any]] = self.base_type.__annotations__
 
         self.field_to_parser: Optional[FieldToParser] = {
             f: get_parser(ftype, cls, extras)

--- a/dataclass_wizard/serial_json.py
+++ b/dataclass_wizard/serial_json.py
@@ -1,6 +1,4 @@
 import json
-# noinspection PyProtectedMember
-from dataclasses import _create_fn, _set_new_attribute
 from typing import Type, List, Union, AnyStr
 
 from .abstractions import AbstractJSONWizard, W
@@ -10,6 +8,8 @@ from .decorators import _alias
 from .dumpers import asdict
 from .loaders import fromdict, fromlist
 from .type_def import Decoder, Encoder, JSONObject, ListOfJSONObject
+# noinspection PyProtectedMember
+from .utils.dataclass_compat import _create_fn, _set_new_attribute
 
 
 class JSONSerializable(AbstractJSONWizard):

--- a/dataclass_wizard/type_def.py
+++ b/dataclass_wizard/type_def.py
@@ -40,12 +40,16 @@ from datetime import date, time, datetime
 from enum import Enum
 from typing import (
     Any, Type, TypeVar, Sequence, Mapping, List, Dict, DefaultDict, FrozenSet,
-    Union, NamedTuple, Callable, AnyStr, TextIO, BinaryIO
+    Union, NamedTuple, Callable, AnyStr, TextIO, BinaryIO,
+    Deque as PyDeque,
+    ForwardRef as PyForwardRef,
+    Literal as PyLiteral,
+    Protocol as PyProtocol,
+    TypedDict as PyTypedDict,
 )
 from uuid import UUID
 
-from .constants import PY36, PY38_OR_ABOVE, PY311_OR_ABOVE
-from .decorators import discard_kwargs
+from .constants import PY311_OR_ABOVE
 
 
 # Type check for numeric types - needed because `bool` is technically
@@ -115,73 +119,25 @@ ListOfJSONObject = List[JSONObject]
 JSONValue = Union[None, str, bool, int, float, JSONList, JSONObject]
 
 
-if PY38_OR_ABOVE:  # pragma: no cover
-    from typing import ForwardRef as PyForwardRef
-    from typing import Literal as PyLiteral
-    from typing import Protocol as PyProtocol
-    from typing import TypedDict as PyTypedDict
-    from typing import Deque as PyDeque
-
-    PyTypedDicts.append(PyTypedDict)
-    # Python 3.8+ users might import from either `typing` or
-    # `typing_extensions`, so check for both types.
-    try:
-        # noinspection PyUnresolvedReferences
-        from typing_extensions import TypedDict as PyTypedDict
-        PyTypedDicts.append(PyTypedDict)
-    except ImportError:
-        pass
-
-    # Python 3.11 introduced `Required` and `NotRequired` wrappers for
-    # `TypedDict` fields (PEP 655). Python 3.8+ users can import the
-    # wrappers from `typing_extensions`.
-    if PY311_OR_ABOVE:
-        from typing import Required as PyRequired
-        from typing import NotRequired as PyNotRequired
-    else:
-        from typing_extensions import Required as PyRequired
-        from typing_extensions import NotRequired as PyNotRequired
-
-else:  # pragma: no cover
-    from typing_extensions import Literal as PyLiteral
-    from typing_extensions import Protocol as PyProtocol
+PyTypedDicts.append(PyTypedDict)
+# Python 3.9+ users might import from either `typing` or
+# `typing_extensions`, so check for both types.
+try:  # pragma: no cover
+    # noinspection PyUnresolvedReferences
     from typing_extensions import TypedDict as PyTypedDict
+    PyTypedDicts.append(PyTypedDict)
+except ImportError:
+    pass
+
+# Python 3.11 introduced `Required` and `NotRequired` wrappers for
+# `TypedDict` fields (PEP 655). Python 3.9+ users can import the
+# wrappers from `typing_extensions`.
+if PY311_OR_ABOVE:  # pragma: no cover
+    from typing import Required as PyRequired
+    from typing import NotRequired as PyNotRequired
+else:
     from typing_extensions import Required as PyRequired
     from typing_extensions import NotRequired as PyNotRequired
-    # Seems like `Deque` was only introduced to `typing` in 3.6.1, so Python
-    # 3.6.0 won't have it; to be safe, we'll instead import from the
-    # `typing_extensions` module here.
-    from typing_extensions import Deque as PyDeque
-
-    PyTypedDicts.append(PyTypedDict)
-
-    if PY36:
-        import typing
-        from typing import _ForwardRef as PyForwardRef
-        from functools import wraps
-
-        # Need to wrap the constructor to discard arguments like `is_argument`
-        PyForwardRef.__init__ = discard_kwargs(PyForwardRef.__init__)
-
-        # This is needed to avoid an`AttributeError` when using PyForwardRef
-        # as an argument to `TypeVar`, as we do below.
-        #
-        # See https://stackoverflow.com/a/69436981/10237506.
-        _old_type_check = typing._type_check
-
-        @wraps(_old_type_check)
-        def _new_type_check(arg, message):
-            if arg is PyForwardRef:
-                return arg
-            return _old_type_check(arg, message)
-
-        typing._type_check = _new_type_check
-        # ensure the global namespace is the same for users
-        # regardless of the version of Python they're using
-        del _new_type_check, typing, wraps
-
-    else:
-        from typing import ForwardRef as PyForwardRef
 
 
 # Forward references can be either strings or explicit `ForwardRef` objects.

--- a/dataclass_wizard/utils/dataclass_compat.py
+++ b/dataclass_wizard/utils/dataclass_compat.py
@@ -1,0 +1,59 @@
+"""
+Pulling some functions removed in recent versions of Python into the module for continued compatibility.
+All function names and bodies are left exactly as they were prior to being removed.
+"""
+
+from dataclasses import MISSING
+from types import FunctionType
+
+
+def _set_qualname(cls, value):
+    # Removed in Python 3.13
+    # Original: `dataclasses._set_qualname`
+    # Ensure that the functions returned from _create_fn uses the proper
+    # __qualname__ (the class they belong to).
+    if isinstance(value, FunctionType):
+        value.__qualname__ = f"{cls.__qualname__}.{value.__name__}"
+    return value
+
+
+def _set_new_attribute(cls, name, value):
+    # Removed in Python 3.13
+    # Original: `dataclasses._set_new_attribute`
+    # Never overwrites an existing attribute.  Returns True if the
+    # attribute already exists.
+    if name in cls.__dict__:
+        return True
+    _set_qualname(cls, value)
+    setattr(cls, name, value)
+    return False
+
+
+def _create_fn(name, args, body, *, globals=None, locals=None,
+               return_type=MISSING):
+    # Removed in Python 3.13
+    # Original: `dataclasses._create_fn`
+    # Note that we may mutate locals. Callers beware!
+    # The only callers are internal to this module, so no
+    # worries about external callers.
+    if locals is None:
+        locals = {}
+    return_annotation = ''
+    if return_type is not MISSING:
+        locals['__dataclass_return_type__'] = return_type
+        return_annotation = '->__dataclass_return_type__'
+    args = ','.join(args)
+    body = '\n'.join(f'  {b}' for b in body)
+
+    # Compute the text of the entire function.
+    txt = f' def {name}({args}){return_annotation}:\n{body}'
+
+    # Free variables in exec are resolved in the global namespace.
+    # The global namespace we have is user-provided, so we can't modify it for
+    # our purposes. So we put the things we need into locals and introduce a
+    # scope to allow the function we're creating to close over them.
+    local_vars = ', '.join(locals.keys())
+    txt = f"def __create_fn__({local_vars}):\n{txt}\n return {name}"
+    ns = {}
+    exec(txt, globals, ns)
+    return ns['__create_fn__'](**locals)

--- a/dataclass_wizard/utils/typing_compat.py
+++ b/dataclass_wizard/utils/typing_compat.py
@@ -22,7 +22,7 @@ import types
 import typing
 
 from .string_conv import repl_or_with_union
-from ..constants import PY310_OR_ABOVE, PY313_OR_ABOVE, PY39
+from ..constants import PY310_OR_ABOVE, PY313_OR_ABOVE
 from ..type_def import FREF, PyLiteral, PyTypedDicts, PyForwardRef
 
 

--- a/dataclass_wizard/utils/typing_compat.py
+++ b/dataclass_wizard/utils/typing_compat.py
@@ -16,6 +16,7 @@ __all__ = [
     'eval_forward_ref_if_needed'
 ]
 
+import functools
 import sys
 import types
 import typing
@@ -351,6 +352,14 @@ def is_annotated(cls):
     return _is_annotated(cls)
 
 
+if PY313_OR_ABOVE:
+    # noinspection PyProtectedMember,PyUnresolvedReferences
+    _eval_type = functools.partial(typing._eval_type, type_params=())
+else:
+    # noinspection PyProtectedMember,PyUnresolvedReferences
+    _eval_type = typing._eval_type
+
+
 def eval_forward_ref(base_type: FREF,
                      cls: typing.Type):
     """
@@ -364,12 +373,7 @@ def eval_forward_ref(base_type: FREF,
     # Evaluate the ForwardRef here
     base_globals = sys.modules[cls.__module__].__dict__
 
-    if PY313_OR_ABOVE:
-        # noinspection PyProtectedMember
-        return typing._eval_type(base_type, base_globals, _TYPING_LOCALS, type_params=())
-    else:
-        # noinspection PyProtectedMember
-        return typing._eval_type(base_type, base_globals, _TYPING_LOCALS)
+    return _eval_type(base_type, base_globals, _TYPING_LOCALS)
 
 
 def eval_forward_ref_if_needed(base_type: typing.Union[typing.Type, FREF],

--- a/dataclass_wizard/utils/typing_compat.py
+++ b/dataclass_wizard/utils/typing_compat.py
@@ -43,7 +43,7 @@ def _get_typing_locals():  # pragma: no cover
     Get typing locals() used to evaluate forward-declared annotations.
 
     This allows standard collections to map to typing Generics; this is used
-    to support PEP-585 syntax for Python 3.7+ (see below)
+    to support PEP-585 syntax for Python 3.9+ (see below)
 
     https://www.python.org/dev/peps/pep-0585/#implementation
     """
@@ -143,11 +143,8 @@ else:  # pragma: no cover
         typing._SpecialForm,
     )
 
-    if PY39:  # PEP 585 is introduced in Python 3.9
-        _TYPING_LOCALS = {'Union': typing.Union}
-
-    else:  # Python 3.7+
-        _TYPING_LOCALS = _get_typing_locals()
+    # PEP 585 is introduced in Python 3.9
+    _TYPING_LOCALS = {'Union': typing.Union}
 
     def _process_forward_annotation(base_type):
         return PyForwardRef(

--- a/dataclass_wizard/utils/typing_compat.py
+++ b/dataclass_wizard/utils/typing_compat.py
@@ -20,10 +20,9 @@ import functools
 import sys
 import types
 import typing
-from collections.abc import Callable
 
 from .string_conv import repl_or_with_union
-from ..constants import PY36, PY38, PY310_OR_ABOVE, PY313_OR_ABOVE, PY39
+from ..constants import PY310_OR_ABOVE, PY313_OR_ABOVE, PY39
 from ..type_def import FREF, PyLiteral, PyTypedDicts, PyForwardRef
 
 
@@ -48,10 +47,7 @@ def _get_typing_locals():  # pragma: no cover
 
     https://www.python.org/dev/peps/pep-0585/#implementation
     """
-    try:
-        from typing import OrderedDict as PyOrderedDict
-    except ImportError:  # Python 3.6
-        from typing_extensions import OrderedDict as PyOrderedDict
+    from typing import OrderedDict as PyOrderedDict
 
     return {
         'Union': typing.Union,
@@ -78,198 +74,105 @@ def get_keys_for_typed_dict(cls):
     return cls.__required_keys__, cls.__optional_keys__
 
 
-if not PY36:    # pragma: no cover
-    # Python 3.7+
+try:  # pragma: no cover
+    from typing_extensions import _AnnotatedAlias
+except ImportError:
+    from typing import _AnnotatedAlias
 
-    try:
-        from typing_extensions import _AnnotatedAlias
-    except ImportError:
-        from typing import _AnnotatedAlias
 
-    def _is_annotated(cls):
-        return isinstance(cls, _AnnotatedAlias)
+def _is_annotated(cls):
+    return isinstance(cls, _AnnotatedAlias)
 
-    def _is_base_generic(cls):
-        if isinstance(cls, typing._GenericAlias):
-            if cls.__origin__ in {typing.Generic, typing._Protocol}:
-                return False
 
-            if isinstance(cls, typing._VariadicGenericAlias):
-                return True
-
-            return len(cls.__parameters__) > 0
-
-        if isinstance(cls, typing._SpecialForm):
-            return cls._name in {'ClassVar', 'Union', 'Optional'}
-
-        return False
-
-    if PY38:
-        def get_keys_for_typed_dict(cls):
-            """
-            Given a :class:`TypedDict` sub-class, returns a pair of
-            (required_keys, optional_keys)
-
-            Note: The `typing` library for Python 3.8 doesn't seem to define
-              the ``__required_keys__`` and ``__optional_keys__`` attributes.
-            """
-            if cls.__total__:
-                return frozenset(cls.__annotations__), frozenset()
-
-            return frozenset(), frozenset(cls.__annotations__)
-
-    def is_literal(cls) -> bool:
-        try:
-            return cls.__origin__ is PyLiteral
-        except AttributeError:
+def _is_base_generic(cls):
+    if isinstance(cls, typing._GenericAlias):
+        if cls.__origin__ in {typing.Generic, typing._Protocol}:
             return False
 
-    # Ref:
-    #   https://github.com/python/typing/blob/master/typing_extensions/src_py3/typing_extensions.py#L2111
-    if PY310_OR_ABOVE:
-        _get_args = typing.get_args
+        if isinstance(cls, typing._VariadicGenericAlias):
+            return True
 
-        _BASE_GENERIC_TYPES = (
-            typing._GenericAlias,
-            typing._SpecialForm,
-            types.GenericAlias,
-            types.UnionType,
-        )
+        return len(cls.__parameters__) > 0
 
-        _TYPING_LOCALS = None
+    if isinstance(cls, typing._SpecialForm):
+        return cls._name in {'ClassVar', 'Union', 'Optional'}
 
-        def _process_forward_annotation(base_type):
-            return PyForwardRef(base_type, is_argument=False)
+    return False
 
-        def _get_origin(cls, raise_=False):
-            if isinstance(cls, types.UnionType):
-                return typing.Union
 
-            try:
-                return cls.__origin__
-            except AttributeError:
-                if raise_:
-                    raise
-                return cls
+def is_literal(cls) -> bool:
+    try:
+        return cls.__origin__ is PyLiteral
+    except AttributeError:
+        return False
 
-    else:
-        from typing_extensions import get_args as _get_args
 
-        _BASE_GENERIC_TYPES = (
-            typing._GenericAlias,
-            typing._SpecialForm,
-        )
+# Ref:
+#   https://github.com/python/typing/blob/master/typing_extensions/src_py3/typing_extensions.py#L2111
+if PY310_OR_ABOVE:  # pragma: no cover
+    _get_args = typing.get_args
 
-        if PY39:  # PEP 585 is introduced in Python 3.9
-            _TYPING_LOCALS = {'Union': typing.Union}
+    _BASE_GENERIC_TYPES = (
+        typing._GenericAlias,
+        typing._SpecialForm,
+        types.GenericAlias,
+        types.UnionType,
+    )
 
-        else:  # Python 3.7+
-            _TYPING_LOCALS = _get_typing_locals()
+    _TYPING_LOCALS = None
 
-        def _process_forward_annotation(base_type):
-            return PyForwardRef(
-                repl_or_with_union(base_type), is_argument=False)
+    def _process_forward_annotation(base_type):
+        return PyForwardRef(base_type, is_argument=False)
 
-        def _get_origin(cls, raise_=False):
-            try:
-                return cls.__origin__
-            except AttributeError:
-                if raise_:
-                    raise
-                return cls
+    def _get_origin(cls, raise_=False):
+        if isinstance(cls, types.UnionType):
+            return typing.Union
 
-    def _get_named_tuple_field_types(cls, raise_=True):
-        """
-        Note: The latest Python versions only support the `__annotations__`
-        attribute.
-        """
         try:
-            return cls.__annotations__
+            return cls.__origin__
         except AttributeError:
             if raise_:
                 raise
-            return None
+            return cls
 
-else:   # pragma: no cover
-    # Python 3.6
+else:  # pragma: no cover
+    from typing_extensions import get_args as _get_args
 
     _BASE_GENERIC_TYPES = (
-        typing._FinalTypingBase,
-        typing.GenericMeta,
+        typing._GenericAlias,
+        typing._SpecialForm,
     )
-    _TYPING_LOCALS = _get_typing_locals()
 
-    from typing_extensions import AnnotatedMeta
+    if PY39:  # PEP 585 is introduced in Python 3.9
+        _TYPING_LOCALS = {'Union': typing.Union}
+
+    else:  # Python 3.7+
+        _TYPING_LOCALS = _get_typing_locals()
 
     def _process_forward_annotation(base_type):
         return PyForwardRef(
             repl_or_with_union(base_type), is_argument=False)
 
-    def _is_base_generic(cls):
-        if isinstance(cls, (typing.GenericMeta, typing._Union)):
-            return cls.__args__ in {None, ()}
-
-        return isinstance(cls, typing._Optional)
-
-    def _is_annotated(cls):
-        return isinstance(cls, AnnotatedMeta)
-
-    # Ref: https://github.com/python/typing/blob/master/typing_extensions/src_py3/typing_extensions.py#L572
-
-    def is_literal(cls) -> bool:
-        try:
-            return cls == PyLiteral[cls.__values__]
-        except AttributeError:
-            return False
-
     def _get_origin(cls, raise_=False):
-
         try:
-            extra = cls.__extra__
-            if extra is None and isinstance(cls, typing.GenericMeta):
-                return typing.Generic
-            return extra
-
-        except AttributeError:
-
-            try:
-                return cls.__origin__
-            except AttributeError:
-                if is_literal(cls):
-                    return PyLiteral
-                if isinstance(cls, typing._ClassVar):
-                    return typing.ClassVar
-                if raise_:
-                    raise
-                return cls
-
-    def _get_args(cls):
-        if is_literal(cls):
-            return cls.__values__
-
-        if is_annotated(cls):
-            return (cls.__args__[0], ) + cls.__metadata__
-
-        try:
-            res = cls.__args__
-            if get_origin(cls) is Callable and res[0] is not Ellipsis:
-                res = (list(res[:-1]), res[-1])
-            return res
-        except AttributeError:
-            # This can happen if it's annotated w/o a subscript, e.g.
-            #   my_union: Union
-            return ()
-
-    def _get_named_tuple_field_types(cls, raise_=True):
-        """
-        Note: Prior to PEP 526, only `_field_types` attribute was assigned.
-        """
-        try:
-            return cls._field_types
+            return cls.__origin__
         except AttributeError:
             if raise_:
                 raise
-            return None
+            return cls
+
+
+def _get_named_tuple_field_types(cls, raise_=True):
+    """
+    Note: The latest Python versions only support the `__annotations__`
+    attribute.
+    """
+    try:
+        return cls.__annotations__
+    except AttributeError:
+        if raise_:
+            raise
+        return None
 
 
 def is_typed_dict(cls: typing.Type) -> bool:

--- a/dataclass_wizard/utils/typing_compat.py
+++ b/dataclass_wizard/utils/typing_compat.py
@@ -38,34 +38,6 @@ for PyTypedDict in PyTypedDicts:
     del RealPyTypedDict
 
 
-def _get_typing_locals():  # pragma: no cover
-    """
-    Get typing locals() used to evaluate forward-declared annotations.
-
-    This allows standard collections to map to typing Generics; this is used
-    to support PEP-585 syntax for Python 3.9+ (see below)
-
-    https://www.python.org/dev/peps/pep-0585/#implementation
-    """
-    from typing import OrderedDict as PyOrderedDict
-
-    return {
-        'Union': typing.Union,
-        'tuple': typing.Tuple,
-        'list': typing.List,
-        'dict': typing.Dict,
-        'set': typing.Set,
-        'frozenset': typing.FrozenSet,
-        'type': typing.Type,
-        # `collections` imports
-        'deque': typing.Deque,
-        'defaultdict': typing.DefaultDict,
-        'OrderedDict': PyOrderedDict,
-        'Counter': typing.Counter,
-        'ChainMap': typing.ChainMap,
-    }
-
-
 def get_keys_for_typed_dict(cls):
     """
     Given a :class:`TypedDict` sub-class, returns a pair of
@@ -144,6 +116,8 @@ else:  # pragma: no cover
     )
 
     # PEP 585 is introduced in Python 3.9
+    # PEP 604 (Allows writing union types as `X | Y`) is introduced
+    #   in Python 3.10
     _TYPING_LOCALS = {'Union': typing.Union}
 
     def _process_forward_annotation(base_type):

--- a/dataclass_wizard/wizard_cli/schema.py
+++ b/dataclass_wizard/wizard_cli/schema.py
@@ -153,11 +153,7 @@ class PyCodeGenerator:
 
 # Global flags (generally passed in via command-line) which are shared by
 # classes and functions.
-#
-# Note: unfortunately we can't annotate it as below, because Python 3.6
-# complains.
-#   Globals: '_Globals' = None
-Globals = None
+Globals: '_Globals | None' = None
 
 
 @dataclass

--- a/docs/common_use_cases/custom_key_mappings.rst
+++ b/docs/common_use_cases/custom_key_mappings.rst
@@ -36,7 +36,7 @@ with IDEs in general.
 .. code:: python3
 
     from dataclasses import dataclass, field
-    from typing_extensions import Annotated
+    from typing import Annotated
 
     from dataclass_wizard import JSONSerializable, json_field, json_key
 
@@ -165,8 +165,7 @@ Using Annotated with a :func:`json_key` argument
 .. code:: python3
 
     from dataclasses import dataclass
-    from typing import Union
-    from typing_extensions import Annotated
+    from typing import Annotated, Union
 
     from dataclass_wizard import JSONSerializable, json_key
 

--- a/docs/common_use_cases/cyclic_or_recursive_dataclasses.rst
+++ b/docs/common_use_cases/cyclic_or_recursive_dataclasses.rst
@@ -1,0 +1,100 @@
+Cyclic or "Recursive" Dataclasses
+=================================
+
+Prior to version ``v0.27.0``, dataclasses with cyclic references
+or self-referential structures were not supported. This
+limitation is shown in the following toy example:
+
+.. code:: python3
+
+    from dataclasses import dataclass
+
+    from dataclass_wizard import JSONWizard
+
+
+    @dataclass
+    class A(JSONWizard):
+        a: 'A | None' = None
+
+
+    a = A.from_dict({'a': {'a': {'a': None}}})
+    assert a == A(a=A(a=A(a=None)))
+
+This has been a `longstanding issue`_.
+
+New in ``v0.27.0``: The Dataclass Wizard now extends its support
+to cyclic and self-referential dataclass models.
+
+The example below demonstrates recursive dataclasses with cyclic
+dependencies, following the pattern ``A -> B -> A -> B``.
+
+With Class Inheritance
+**********************
+
+Here’s a basic example demonstrating the use of recursive dataclasses
+with cyclic dependencies, using a class inheritance model and
+the :class:`JSONWizard` mixin:
+
+.. code:: python3
+
+    from __future__ import annotations  # This can be removed in Python 3.10+
+
+    from dataclasses import dataclass
+
+    from dataclass_wizard import JSONWizard
+
+
+    @dataclass
+    class A(JSONWizard):
+        class _(JSONWizard.Meta):
+            # enable support for self-referential / recursive dataclasses
+            recursive_classes = True
+
+        b: 'B | None' = None
+
+
+    @dataclass
+    class B:
+        a: A | None = None
+
+
+    # confirm that `from_dict` with a recursive, self-referential
+    # input `dict` works as expected.
+    a = A.from_dict({'b': {'a': {'b': {'a': None}}}})
+    assert a == A(b=B(a=A(b=B())))
+
+Without Class Inheritance
+*************************
+
+Here is the same example as above, but with relying solely on ``dataclasses``, without
+using any special class inheritance model:
+
+
+.. code:: python3
+
+    from __future__ import annotations  # This can be removed in Python 3.10+
+
+    from dataclasses import dataclass
+
+    from dataclass_wizard import fromdict, LoadMeta
+
+
+    @dataclass
+    class A:
+        b: 'B | None' = None
+
+
+    @dataclass
+    class B:
+        a: A | None = None
+
+
+    # enable support for self-referential / recursive dataclasses
+    LoadMeta(recursive_classes=True).bind_to(A)
+
+    # confirm that `from_dict` with a recursive, self-referential
+    # input `dict` works as expected.
+    a = fromdict(A, {'b': {'a': {'b': {'a': None}}}})
+    assert a == A(b=B(a=A(b=B())))
+
+.. _longstanding issue: https://github.com/rnag/dataclass-wizard/issues/62

--- a/docs/common_use_cases/dataclasses_in_union_types.rst
+++ b/docs/common_use_cases/dataclasses_in_union_types.rst
@@ -39,8 +39,8 @@ Let's start out with an example, which aims to demonstrate the simplest usage of
 dataclasses in ``Union`` types.
 
 .. note::
-   The below example should work for **Python 3.7+** with the included ``__future__``
-   import. Note that for 3.6, the ``A | B`` syntax -- which represents `Union`_ types --
+   The below example should work for **Python 3.9+** with the included ``__future__``
+   import. In Python 3.9, without the ``__future__`` import, the ``A | B`` syntax -- which represents `Union`_ types --
    can be replaced with ``typing.Union[A, B]`` instead. Similarly, the subscripted
    ``dict`` usage can be substituted with a ``typing.Dict`` as needed.
 

--- a/docs/common_use_cases/patterned_date_time.rst
+++ b/docs/common_use_cases/patterned_date_time.rst
@@ -45,7 +45,7 @@ The usage is shown below, and is again pretty straightforward.
     from dataclasses import dataclass
     from datetime import datetime
 
-    from typing_extensions import Annotated
+    from typing import Annotated
 
     from dataclass_wizard import JSONWizard, Pattern, DatePattern, TimePattern
 
@@ -104,9 +104,8 @@ of date-time, for example a subclass of :class:`date` if so desired.
 
     from dataclasses import dataclass
     from datetime import datetime, time
-    from typing import List, Dict
 
-    from typing_extensions import Annotated
+    from typing import Annotated
 
     from dataclass_wizard import JSONWizard, Pattern
 
@@ -120,8 +119,8 @@ of date-time, for example a subclass of :class:`date` if so desired.
     @dataclass
     class MyClass(JSONWizard):
 
-        time_field: Annotated[List[MyTime], Pattern('%I:%M %p')]
-        dt_mapping: Annotated[Dict[int, datetime], Pattern('%b.%d.%y %H,%M,%S')]
+        time_field: Annotated[list[MyTime], Pattern('%I:%M %p')]
+        dt_mapping: Annotated[dict[int, datetime], Pattern('%b.%d.%y %H,%M,%S')]
 
 
     data = {'time_field': ['3:45 PM', '1:20 am', '12:30 pm'],

--- a/docs/common_use_cases/serialization_options.rst
+++ b/docs/common_use_cases/serialization_options.rst
@@ -21,7 +21,6 @@ approaches is shown below.
 
     from collections import defaultdict
     from dataclasses import field, dataclass
-    from typing import DefaultDict, List
 
     from dataclass_wizard import JSONWizard
 
@@ -35,8 +34,8 @@ approaches is shown below.
         my_str: str
         other_str: str = 'any value'
         optional_str: str = None
-        my_list: List[str] = field(default_factory=list)
-        my_dict: DefaultDict[str, List[float]] = field(
+        my_list: list[str] = field(default_factory=list)
+        my_dict: defaultdict[str, list[float]] = field(
             default_factory=lambda: defaultdict(list))
 
 

--- a/docs/common_use_cases/skip_inheritance.rst
+++ b/docs/common_use_cases/skip_inheritance.rst
@@ -25,7 +25,7 @@ Here is an example to demonstrate the usage of these helper functions:
 
     from dataclasses import dataclass
     from datetime import datetime
-    from typing import List, Optional, Union
+    from typing import Optional, Union
 
     from dataclass_wizard import fromdict, asdict, DumpMeta
 
@@ -34,7 +34,7 @@ Here is an example to demonstrate the usage of these helper functions:
     class Container:
         id: int
         created_at: datetime
-        my_elements: List['MyElement']
+        my_elements: list['MyElement']
 
 
     @dataclass

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -4,8 +4,7 @@ Examples
 Simple
 ~~~~~~
 
-The following example has been tested on **Python 3.7+**. See below for an
-alternate version that is supported in Python 3.6+.
+The following example has been tested on **Python 3.9+**.
 
 .. code:: python3
 
@@ -46,10 +45,10 @@ alternate version that is supported in Python 3.6+.
     # True
     assert c == c.from_dict(c.to_dict())
 
-Using Typing Imports
---------------------
+Using Typing Imports (Deprecated)
+---------------------------------
 
-This approach is supported in **Python 3.6+**. Usage is the same as above.
+This approach is supported in **Python 3.6**. Usage is the same as above.
 
 .. code:: python3
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -73,18 +73,16 @@ A (More) Complete Example
     from collections import defaultdict
     from dataclasses import dataclass, field
     from datetime import datetime
-    from typing import Optional, List, Union, Dict, Any, NamedTuple, DefaultDict
-    # Note: for Python 3.9+, you can import the following from `typing` instead
-    from typing_extensions import Literal
+    from typing import Optional, Literal, Union, Any, NamedTuple
 
     from dataclass_wizard import JSONSerializable
 
 
     @dataclass
     class MyTestClass(JSONSerializable):
-        my_ledger: Dict[str, Any]
+        my_ledger: dict[str, Any]
         the_answer_to_life: Optional[int]
-        people: List['Person']
+        people: list['Person']
         is_enabled: bool = True
 
 
@@ -94,8 +92,8 @@ A (More) Complete Example
         age: int
         birthdate: datetime
         gender: Literal['M', 'F', 'N/A']
-        occupation: Union[str, List[str]]
-        hobbies: DefaultDict[str, List[str]] = field(
+        occupation: Union[str, list[str]]
+        hobbies: defaultdict[str, list[str]] = field(
             default_factory=lambda: defaultdict(list))
 
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -4,7 +4,7 @@ Overview
 Requirements
 ~~~~~~~~~~~~
 
-The ``dataclass-wizard`` library officially supports **Python 3.6+**
+The ``dataclass-wizard`` library officially supports **Python 3.9+**
 
 There are no core requirements outside of the Python standard library. That being
 said, this library *does* utilize a few conditional dependencies:
@@ -12,8 +12,6 @@ said, this library *does* utilize a few conditional dependencies:
 * `typing-extensions` - this is a lightweight and highly useful library that backports
   the most recently added features to the ``typing`` module. For more info,
   check out the :doc:`python_compatibility` section.
-* `dataclasses` - a backport of the ``dataclasses`` module for Python 3.6
-* `backports-datetime-fromisoformat` - a backport of `fromisoformat()`_ for Python 3.6
 
 Advantages
 ~~~~~~~~~~
@@ -95,8 +93,7 @@ Supported Types
     - ``Union`` - Also supports `using dataclasses`_.
     - ``Optional``
 
-* Recently introduced Generic types (available in Python 3.6+ via the ``typing-extensions``
-  module)
+* Recently introduced Generic types
     - ``Annotated``
     - ``Literal``
 

--- a/docs/python_compatibility.rst
+++ b/docs/python_compatibility.rst
@@ -20,9 +20,16 @@ this dependency for **Python version 3.10 or earlier**, so there's no need
 to install this library separately.
 
 With the ``typing-extensions`` module, you can take advantage of the
-following new types from the ``typing`` module for Python 3.6+. Most of them are currently
+following new types from the ``typing`` module for Python 3.9+. Most of them are currently
 supported by the ``JSONSerializable`` class, however the ones that are *not*
 are marked with an asterisk (``*``) below.
+
+Introduced in *Python 3.10*:
+    * `is_typeddict`_
+    * `Concatenate`_
+    * `ParamSpec`_
+    * `TypeAlias`_
+    * `TypeGuard`_
 
 Introduced in *Python 3.9*:
     * `Annotated`_ (added by `PEP 593`_)
@@ -31,9 +38,6 @@ Introduced in *Python 3.8*:
     * `Literal`_
     * `TypedDict`_
     * `Final`_ ``*``
-
-Introduced in *Python 3.7*:
-    * `OrderedDict`_
 
 
 ``*`` - Currently not supported by ``JSONSerializable`` at this time, though this
@@ -44,8 +48,12 @@ may change in a future release.
 .. _PEP 593: https://www.python.org/dev/peps/pep-0593/
 .. _Final: https://docs.python.org/3.8/library/typing.html#typing.Final
 .. _Literal: https://docs.python.org/3.8/library/typing.html#typing.Literal
-.. _OrderedDict: https://docs.python.org/3.7/library/typing.html#typing.OrderedDict
 .. _TypedDict: https://docs.python.org/3.8/library/typing.html#typing.TypedDict
+.. _TypeAlias: https://docs.python.org/3/library/typing.html#typing.TypeAlias
+.. _Concatenate: https://docs.python.org/3/library/typing.html#typing.Concatenate
+.. _TypeGuard: https://docs.python.org/3/library/typing.html#typing.TypeGuard
+.. _ParamSpec: https://docs.python.org/3/library/typing.html#typing.ParamSpec
+.. _is_typeddict: https://docs.python.org/3/library/typing.html#typing.is_typeddict
 
 Importing the New Types
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/python_compatibility.rst
+++ b/docs/python_compatibility.rst
@@ -4,10 +4,10 @@
 Py Compatibility
 ================
 
-Python 3.6+
+Python 3.9+
 -----------
 
-Just a quick note that even though this library supports Python 3.6+,
+Just a quick note that even though this library supports Python 3.9+,
 some of the new features introduced in the latest Python
 versions might not be available from the ``typing`` module, depending on
 the Python version installed.
@@ -16,7 +16,7 @@ To work around that, there's a great library called ``typing-extensions`` (you c
 find it on PyPI `here`_) that backports all the new
 ``typing`` features introduced so that earlier Python versions can also
 benefit from them. Note that the ``dataclass-wizard`` package already requires
-this dependency for **Python version 3.9 or earlier**, so there's no need
+this dependency for **Python version 3.10 or earlier**, so there's no need
 to install this library separately.
 
 With the ``typing-extensions`` module, you can take advantage of the

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -17,7 +17,7 @@ and declare and use field properties with default values.
 
     from dataclasses import dataclass, field
     from datetime import datetime
-    from typing import Optional, List
+    from typing import Optional
 
     from dataclass_wizard import JSONSerializable, property_wizard
 
@@ -26,7 +26,7 @@ and declare and use field properties with default values.
     class MyClass(JSONSerializable, metaclass=property_wizard):
 
         my_str: Optional[str]
-        list_of_int: List[int] = field(default_factory=list)
+        list_of_int: list[int] = field(default_factory=list)
         # You can also define this as `my_dt`, however only the annotation
         # will carry over in that case, since the value is re-declared by
         # the property below. See also the 'Using Field Properties' section

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,1 @@
-sphinx-issues==3.0.1; python_version < "3.8"
-sphinx-issues==4.0.0; python_version >= "3.8"
+sphinx-issues==5.0.0

--- a/docs/using_field_properties.rst
+++ b/docs/using_field_properties.rst
@@ -189,14 +189,12 @@ But fortunately... there is yet an even simpler approach!
 Using the `Annotated`_ type from the ``typing`` module (introduced in Python 3.9)
 it is possible to set a default value for the field property in the annotation itself.
 This is done by adding a ``field`` extra in the ``Annotated`` definition as
-shown below; here we'll instead import the type from the ``typing-extensions``
-module, just so that the code works for Python 3.6+ without issue.
+shown below.
 
 .. code:: python3
 
     from dataclasses import dataclass, field
-    from typing import Union
-    from typing_extensions import Annotated
+    from typing import Annotated, Union
 
     from dataclass_wizard import property_wizard
 

--- a/docs/using_field_properties.rst
+++ b/docs/using_field_properties.rst
@@ -292,36 +292,35 @@ types are now set with initial values as expected:
 
     from collections import defaultdict
     from dataclasses import dataclass, field
-    from typing import Union, List, Set, DefaultDict
-    from typing_extensions import Annotated
+    from typing import Annotated, Union
 
     from dataclass_wizard import property_wizard
 
 
     @dataclass
     class Vehicle(metaclass=property_wizard):
-        wheels: List[Union[int, str]]
+        wheels: list[Union[int, str]]
         # Uncomment the field below if you want to make your IDE a bit happier.
-        #   _wheels: List[int] = field(init=False)
+        #   _wheels: list[int] = field(init=False)
 
-        inverse_bools: Set[bool]
+        inverse_bools: set[bool]
         # If we wanted to, we can also define this as below:
-        #   inverse_bools: Annotated[Set[bool], field(default_factory=set)]
+        #   inverse_bools: Annotated[set[bool], field(default_factory=set)]
 
         # We need to use the `field(default_factory=...)` syntax here, because
         # otherwise the value is initialized from the no-args constructor,
         # i.e. `defaultdict()`, which is not what we want.
         inventory: Annotated[
-            DefaultDict[str, List[Union[int, str]]],
+            defaultdict[str, list[Union[int, str]]],
             field(default_factory=lambda: defaultdict(list))
         ]
 
         @property
-        def wheels(self) -> List[int]:
+        def wheels(self) -> list[int]:
             return self._wheels
 
         @wheels.setter
-        def wheels(self, wheels: List[Union[int, str]]):
+        def wheels(self, wheels: list[Union[int, str]]):
             # Try to avoid a list comprehension, as that will defeat the point
             # of this example (as that generates a list with a new "id").
             for i, w in enumerate(wheels):
@@ -329,11 +328,11 @@ types are now set with initial values as expected:
             self._wheels = wheels
 
         @property
-        def inverse_bools(self) -> Set[bool]:
+        def inverse_bools(self) -> set[bool]:
             return self._inverse_bools
 
         @inverse_bools.setter
-        def inverse_bools(self, bool_set: Set[bool]):
+        def inverse_bools(self, bool_set: set[bool]):
             # Again, try to avoid a set comprehension here for demo purposes.
             for b in bool_set:
                 to_add = not b
@@ -344,11 +343,11 @@ types are now set with initial values as expected:
             self._inverse_bools = bool_set
 
         @property
-        def inventory(self) -> DefaultDict[str, List[Union[int, str]]]:
+        def inventory(self) -> defaultdict[str, list[Union[int, str]]]:
             return self._inventory
 
         @inventory.setter
-        def inventory(self, inventory: DefaultDict[str, List[Union[int, str]]]):
+        def inventory(self, inventory: defaultdict[str, list[Union[int, str]]]):
             if 'Keys' in inventory:
                 del inventory['Keys']
             self._inventory = inventory

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,9 +41,7 @@ requirements:
     - pip
   run:
     - python
-    - backports-datetime-fromisoformat ==1.0.0  # [py==36]
-    - dataclasses  # [py==36]
-    - typing-extensions >=3.7.4.2  # [py<=39]
+    - typing-extensions >=4  # [py<=310]
 
 test:
   imports:
@@ -71,7 +69,7 @@ about:
   description: |
     The dataclass-wizard library provides a set of simple, yet
     elegant *wizarding* tools for interacting with the Python
-    `dataclasses` module in Python 3.6+.
+    `dataclasses` module in Python 3.9+.
 
     The primary use is as a fast serialization framework that enables
     dataclass instances to be converted to/from JSON; this works well

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ build:
   script: {{ PYTHON }} -m pip install . -vv
   noarch: python
   # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
-  skip: True  # [py<36]
+  skip: True  # [py<39]
 
 requirements:
   host:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,14 @@
+# TODO It seems `pip-upgrader` does not support Python 3.11+
+# pip-upgrader==1.4.15
 flake8>=3  # pyup: ignore
-tox==3.24.5
+tox==4.23.2
 # Extras
 pytimeparse==1.1.8
 # TODO I don't know if we need the below on CI
 coverage>=6.2
 pip>=21.3.1
 bump2version==1.0.1
-wheel==0.37.1; python_version == "3.6"
-wheel==0.42.0; python_version > "3.6"
-watchdog[watchmedo]==2.1.6
-Sphinx==5.3.0
-twine==3.8.0
+wheel==0.45.0
+watchdog[watchmedo]==6.0.0
+Sphinx==8.1.3
+twine==5.1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,5 +10,6 @@ pip>=21.3.1
 bump2version==1.0.1
 wheel==0.45.0
 watchdog[watchmedo]==6.0.0
-Sphinx==8.1.3
+Sphinx==7.4.7; python_version == "3.9"
+Sphinx==8.1.3; python_version >= "3.10"
 twine==5.1.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,8 @@
-pytest==7.0.1
+pytest==8.3.3
 pytest-mock>=3.6.1
-pytest-cov==3.0.0
+pytest-cov==6.0.0
 # pytest-runner==5.3.1
 # Benchmark tests
-dataclasses-json==0.5.6
-jsons==1.6.1
-dataclass-factory==2.12  # pyup: ignore
+dataclasses-json==0.6.7
+jsons==1.6.3
+dataclass-factory==2.16  # pyup: ignore

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.25.0
+current_version = 0.26.0
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,5 @@ universal = 1
 [flake8]
 exclude = docs
 
-[options.package_data]
-* = *.txt, *.rst, *.md, py.typed
-
 [tool:pytest]
 collect_ignore = ['setup.py']

--- a/setup.py
+++ b/setup.py
@@ -15,28 +15,19 @@ requires = [
     'typing-extensions>=4; python_version == "3.9" or python_version == "3.10"',
 ]
 
-# TODO update once we drop support for Python 3.6 & 3.7
-# if (requires_dev_file := here / 'requirements-dev.txt').exists():
-requires_dev_file = here / 'requirements-dev.txt'
-if requires_dev_file.exists():
+if (requires_dev_file := here / 'requirements-dev.txt').exists():
     with requires_dev_file.open() as requires_dev_txt:
         dev_requires = [str(req) for req in parse_requirements(requires_dev_txt)]
 else:   # Running on CI
     dev_requires = []
 
-# TODO update once we drop support for Python 3.6 & 3.7
-# if (requires_docs_file := here / 'docs' / 'requirements.txt').exists():
-requires_docs_file = here / 'docs' / 'requirements.txt'
-if requires_docs_file.exists():
+if (requires_docs_file := here / 'docs' / 'requirements.txt').exists():
     with requires_docs_file.open() as requires_docs_txt:
         doc_requires = [str(req) for req in parse_requirements(requires_docs_txt)]
 else:   # Running on CI
     doc_requires = []
 
-# TODO update once we drop support for Python 3.6 & 3.7
-# if (requires_test_file := here / 'requirements-test.txt').exists():
-requires_test_file = here / 'requirements-test.txt'
-if requires_test_file.exists():
+if (requires_test_file := here / 'requirements-test.txt').exists():
     with requires_test_file.open() as requires_test_txt:
         test_requirements = [str(req) for req in parse_requirements(requires_test_txt)]
 else:   # Running on CI
@@ -85,9 +76,6 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ package_name = 'dataclass_wizard'
 packages = find_packages(include=[package_name, f'{package_name}.*'])
 
 requires = [
-    'typing-extensions>=4; python_version == "3.9"',
+    'typing-extensions>=4; python_version == "3.9" or python_version == "3.10"',
 ]
 
 # TODO update once we drop support for Python 3.6 & 3.7

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Programming Language :: Python'
     ],
     test_suite='tests',

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,7 @@ package_name = 'dataclass_wizard'
 packages = find_packages(include=[package_name, f'{package_name}.*'])
 
 requires = [
-    'typing-extensions>=3.7.4.2; python_version <= "3.9"',
-    'dataclasses; python_version == "3.6"',
-    'backports-datetime-fromisoformat==1.0.0; python_version == "3.6"'
+    'typing-extensions>=4; python_version == "3.9"',
 ]
 
 # TODO update once we drop support for Python 3.6 & 3.7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,26 +3,20 @@ __all__ = [
     'data_file_path',
     'PY310_OR_ABOVE',
     'PY311_OR_ABOVE',
-    # For compatibility with Python 3.6 and 3.7
-    'Literal',
     'TypedDict',
-    'Annotated',
-    'Deque',
-    # For compatibility with Python 3.6 through 3.10
+    # For compatibility with Python 3.9 and 3.10
     'Required',
     'NotRequired'
 ]
 
 import sys
+# Ref: https://docs.pytest.org/en/6.2.x/example/parametrize.html#parametrizing-conditional-raising
+from contextlib import nullcontext as does_not_raise
 from pathlib import Path
 
 
 # Directory for test files
 TEST_DATA_DIR = Path(__file__).resolve().parent / 'testdata'
-
-# Check if we are running Python 3.9 or 3.10
-PY39 = sys.version_info[:2] == (3, 9)
-PY310 = sys.version_info[:2] == (3, 10)
 
 # Check if we are running Python 3.10+
 PY310_OR_ABOVE = sys.version_info[:2] >= (3, 10)
@@ -30,34 +24,15 @@ PY310_OR_ABOVE = sys.version_info[:2] >= (3, 10)
 # Check if we are running Python 3.11+
 PY311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
 
-# Ref: https://docs.pytest.org/en/6.2.x/example/parametrize.html#parametrizing-conditional-raising
-if sys.version_info[:2] >= (3, 7):
-    from contextlib import nullcontext as does_not_raise
-else:
-    from contextlib import ExitStack as does_not_raise
-
-# TODO typing.Deque is deprecated since PY 3.9
-#   https://docs.python.org/3/library/typing.html#typing.Deque
-try:
-    # Introduced in Python 3.6
-    from typing import Deque
-    # Introduced in Python 3.8
-    from typing import Literal
-    from typing import TypedDict
-except ImportError:
-    # Introduced in Python 3.6
-    from typing_extensions import Deque
-    # Introduced in Python 3.8
-    from typing_extensions import Literal
-    from typing_extensions import TypedDict
+# Check if we are running Python 3.9 or 3.10
+PY310_OR_EARLIER = not PY311_OR_ABOVE
 
 # Weird, test cases for `TypedDict` fail in Python 3.9 & 3.10.15 (3.10:latest)
 # So apparently, we need to use the one from `typing_extensions`.
-if PY39 or PY310:
+if PY310_OR_EARLIER:
     from typing_extensions import TypedDict
-
-# typing.Annotated: Introduced in Python 3.9
-from typing import Annotated
+else:
+    from typing import TypedDict
 
 # typing.Required and typing.NotRequired: Introduced in Python 3.11
 if PY311_OR_ABOVE:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,6 @@
 __all__ = [
     'does_not_raise',
     'data_file_path',
-    'PY36',
-    'PY38',
-    'PY39_OR_ABOVE',
     'PY310_OR_ABOVE',
     'PY311_OR_ABOVE',
     # For compatibility with Python 3.6 and 3.7
@@ -22,15 +19,6 @@ from pathlib import Path
 
 # Directory for test files
 TEST_DATA_DIR = Path(__file__).resolve().parent / 'testdata'
-
-# Check if we are running Python 3.6
-PY36 = sys.version_info[:2] == (3, 6)
-
-# Check if we are running Python 3.8
-PY38 = sys.version_info[:2] == (3, 8)
-
-# Check if we are running Python 3.9+
-PY39_OR_ABOVE = sys.version_info[:2] >= (3, 9)
 
 # Check if we are running Python 3.9 or 3.10
 PY39 = sys.version_info[:2] == (3, 9)
@@ -69,10 +57,7 @@ if PY39 or PY310:
     from typing_extensions import TypedDict
 
 # typing.Annotated: Introduced in Python 3.9
-if PY39_OR_ABOVE:
-    from typing import Annotated
-else:
-    from typing_extensions import Annotated
+from typing import Annotated
 
 # typing.Required and typing.NotRequired: Introduced in Python 3.11
 if PY311_OR_ABOVE:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,23 +4,12 @@ Common test fixtures and utilities.
 from dataclasses import dataclass
 from uuid import UUID
 
-from ..conftest import PY36
-
 
 @dataclass
 class SampleClass:
     """Sample dataclass model for various test scenarios."""
     f1: str
     f2: int
-
-
-if PY36:
-    # Ignore these files, because Python 3.6 doesn't define the `__future__`
-    # import used, so we'll run into an error if we import these modules.
-    #
-    # Ref: https://docs.pytest.org/en/6.2.x/example/pythoncollection.html#customizing-test-collection
-    collect_ignore = ['test_load_with_future_import.py',
-                      'test_property_wizard_with_future_import.py']
 
 
 class MyUUIDSubclass(UUID):

--- a/tests/unit/test_dump.py
+++ b/tests/unit/test_dump.py
@@ -3,7 +3,8 @@ from abc import ABC
 from collections import deque, defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Set, FrozenSet, Optional, Union, List, DefaultDict
+from typing import (Set, FrozenSet, Optional, Union, List,
+                    DefaultDict, Annotated, Literal)
 from uuid import UUID
 
 import pytest
@@ -343,7 +344,7 @@ def test_deque(input, expected, expectation):
 
     @dataclass
     class MyQClass(JSONSerializable):
-        num_deque: Deque[int]
+        num_deque: deque[int]
         any_deque: deque
 
     input_deque = deque(input)

--- a/tests/unit/test_load.py
+++ b/tests/unit/test_load.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, date, time, timedelta
 from typing import (
     List, Optional, Union, Tuple, Dict, NamedTuple, Type, DefaultDict,
-    Set, FrozenSet, Generic
+    Set, FrozenSet, Generic, Annotated, Literal
 )
 
 import pytest
@@ -960,7 +960,7 @@ def test_deque(input, expectation, expected):
 
     @dataclass
     class MyClass(JSONSerializable):
-        my_deque: Deque[int]
+        my_deque: deque[int]
 
     d = {'My_Deque': input}
 

--- a/tests/unit/test_load.py
+++ b/tests/unit/test_load.py
@@ -120,7 +120,6 @@ def test_fromdict_with_nested_dataclass():
     ]
 
 
-@pytest.mark.skipif(PY36, reason='requires Python 3.7 or higher')
 def test_invalid_types_with_debug_mode_enabled():
     """
     Passing invalid types (i.e. that *can't* be coerced into the annotated
@@ -178,7 +177,6 @@ def test_invalid_types_with_debug_mode_enabled():
     assert (err.ann_type, err.obj_type) == (int, dict)
 
 
-@pytest.mark.skipif(PY36, reason='requires Python 3.7 or higher')
 def test_from_dict_called_with_incorrect_type():
     """
     Calling `from_dict` with a non-`dict` argument should raise a
@@ -201,7 +199,6 @@ def test_from_dict_called_with_incorrect_type():
     assert (err.ann_type, err.obj_type) == (dict, list)
 
 
-@pytest.mark.skipif(PY36, reason='requires Python 3.7 or higher')
 def test_date_times_with_custom_pattern():
     """
     Date, time, and datetime objects with a custom date string
@@ -289,7 +286,6 @@ def test_date_times_with_custom_pattern():
     assert fromdict(MyClass, serialized_dict) == expected_obj
 
 
-@pytest.mark.skipif(PY36, reason='requires Python 3.7 or higher')
 def test_date_times_with_custom_pattern_when_input_is_invalid():
     """
     Date, time, and datetime objects with a custom date string
@@ -306,7 +302,6 @@ def test_date_times_with_custom_pattern_when_input_is_invalid():
         _ = fromdict(MyClass, data)
 
 
-@pytest.mark.skipif(PY36, reason='requires Python 3.7 or higher')
 def test_date_times_with_custom_pattern_when_annotation_is_invalid():
     """
     Date, time, and datetime objects with a custom date string
@@ -746,12 +741,7 @@ def test_optional(input, expectation, expected):
         # The actual value would end up being 0 (int) if we checked the type
         # using `isinstance` instead. However, we do an exact `type` check for
         # :class:`Union` types.
-        #
-        # NOTE: This is an xfail on Python 3.6 as mentioned below.
-        # https://stackoverflow.com/q/60154326/10237506
-        pytest.param(False, does_not_raise(), False,
-                     marks=pytest.mark.skipif(
-                         PY36, reason='requires python 3.7 or higher')),
+        (False, does_not_raise(), False),
         (0, does_not_raise(), 0),
         (None, does_not_raise(), None),
         # Since it's a float value, that results in a `TypeError` which gets
@@ -912,10 +902,7 @@ def test_timedelta(input, expectation, base_err):
         log.debug('timedelta string value: %s', result.my_td)
 
     if e:  # if an error was raised, assert the underlying error type
-        # Because on 3.6, we run into a strange error (shown below)
-        #   AttributeError: 'ExitStack' object has no attribute 'value'
-        if not PY36:
-            assert type(e.value.base_error) == base_err
+        assert type(e.value.base_error) == base_err
 
 
 @pytest.mark.parametrize(
@@ -1426,7 +1413,6 @@ def test_typed_dict_with_all_fields_optional(input, expectation, expected):
         assert result.my_typed_dict == expected
 
 
-@pytest.mark.skipif(PY36 or PY38, reason='requires Python 3.7 or higher')
 @pytest.mark.parametrize(
     'input,expectation,expected',
     [
@@ -1489,7 +1475,6 @@ def test_typed_dict_with_one_field_not_required(input, expectation, expected):
         assert result.my_typed_dict == expected
 
 
-@pytest.mark.skipif(PY36 or PY38, reason='requires Python 3.9 or higher')
 @pytest.mark.parametrize(
     'input,expectation,expected',
     [

--- a/tests/unit/test_load.py
+++ b/tests/unit/test_load.py
@@ -1801,3 +1801,30 @@ def test_load_with_inner_model_when_data_is_wrong_type():
     # the error should mention that we want a dict, but get a list
     assert e.ann_type == dict
     assert e.obj_type == list
+
+
+def test_load_with_python_3_11_regression():
+    """
+    This test case is to confirm intended operation with `typing.Any`
+    (either explicit or implicit in plain `list` or `dict` type
+    annotations).
+
+    Note: I have been unable to reproduce [the issue] posted on GitHub.
+    I've tested this on multiple Python versions on Mac, including
+    3.10.6, 3.11.0, 3.11.5, 3.11.10.
+
+    See [the issue].
+
+    [the issue]: https://github.com/rnag/dataclass-wizard/issues/89
+    """
+
+    @dataclass
+    class Item(JSONSerializable):
+        a: dict
+        b: Optional[dict]
+        c: Optional[list] = None
+
+    item = Item.from_json('{"a": {}, "b": null}')
+
+    assert item.a == {}
+    assert item.b is item.c is None

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -2,10 +2,9 @@ import pytest
 
 from dataclass_wizard.parsers import LiteralParser
 
-from ..conftest import Literal, PY39_OR_ABOVE
+from ..conftest import Literal
 
 
-@pytest.mark.skipif(not PY39_OR_ABOVE, reason='requires Python 3.9 or higher')
 class TestLiteralParser:
     @pytest.fixture
     def literal_parser(self) -> LiteralParser:

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -1,0 +1,17 @@
+from typing import Literal
+
+import pytest
+
+from dataclass_wizard.parsers import LiteralParser
+
+
+class TestLiteralParser:
+    @pytest.fixture
+    def literal_parser(self) -> LiteralParser:
+        return LiteralParser(cls=object, base_type=Literal["foo"], extras={})
+
+    def test_literal_parser_dunder_contains_succeeds_if_item_in_keys_of_base_type(self, literal_parser):
+        assert "foo" in literal_parser
+
+    def test_literal_parser_dunder_contains_fails_if_item_not_in_keys_of_base_type(self, literal_parser):
+        assert "bar" not in literal_parser

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -1,8 +1,8 @@
 import pytest
 
-from dataclass_wizard.parsers import LiteralParser
+from typing import Literal
 
-from ..conftest import Literal
+from dataclass_wizard.parsers import LiteralParser
 
 
 class TestLiteralParser:

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -1,10 +1,11 @@
-from typing import Literal
-
 import pytest
 
 from dataclass_wizard.parsers import LiteralParser
 
+from ..conftest import Literal, PY39_OR_ABOVE
 
+
+@pytest.mark.skipif(not PY39_OR_ABOVE, reason='requires Python 3.9 or higher')
 class TestLiteralParser:
     @pytest.fixture
     def literal_parser(self) -> LiteralParser:

--- a/tests/unit/test_property_wizard.py
+++ b/tests/unit/test_property_wizard.py
@@ -7,7 +7,7 @@ from typing import Union, List, ClassVar, DefaultDict, Set
 import pytest
 
 from dataclass_wizard import property_wizard
-from ..conftest import Literal, Annotated, PY39_OR_ABOVE, PY310_OR_ABOVE
+from ..conftest import Literal, Annotated, PY310_OR_ABOVE
 
 log = logging.getLogger(__name__)
 
@@ -1101,7 +1101,6 @@ def test_property_wizard_with_mutable_types_v2():
     assert v3.wheels_list == [5, 5]
 
 
-@pytest.mark.skipif(not PY39_OR_ABOVE, reason='requires Python 3.9 or higher')
 def test_property_wizard_with_mutable_types_with_parameterized_standard_collections():
     """
     Test case for mutable types with a Python 3.9 specific feature:

--- a/tests/unit/test_property_wizard.py
+++ b/tests/unit/test_property_wizard.py
@@ -2,12 +2,12 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Union, List, ClassVar, DefaultDict, Set
+from typing import Union, List, ClassVar, DefaultDict, Set, Literal, Annotated
 
 import pytest
 
 from dataclass_wizard import property_wizard
-from ..conftest import Literal, Annotated, PY310_OR_ABOVE
+from ..conftest import PY310_OR_ABOVE
 
 log = logging.getLogger(__name__)
 

--- a/tests/unit/utils/test_typing_compat.py
+++ b/tests/unit/utils/test_typing_compat.py
@@ -30,15 +30,8 @@ def test_get_origin(tp, expected):
         (Dict[str, int], (str, int)),
         (int, ()),
         (Callable[[], T][int], ([], int)),
-        # The following cases are an `xfail` on Python 3.6
-        pytest.param(
-            Union[int, Union[T, int], str][int], (int, str),
-                     marks=pytest.mark.skipif(
-                         PY36, reason='requires python 3.7 or higher')),
-        pytest.param(
-            Union[int, Tuple[T, int]][str], (int, Tuple[str, int]),
-            marks=pytest.mark.skipif(
-                PY36, reason='requires python 3.7 or higher')),
+        (Union[int, Union[T, int], str][int], (int, str)),
+        (Union[int, Tuple[T, int]][str], (int, Tuple[str, int])),
     ]
 )
 def test_get_args(tp, expected):

--- a/tests/unit/utils/test_typing_compat.py
+++ b/tests/unit/utils/test_typing_compat.py
@@ -1,10 +1,9 @@
-from typing import ClassVar, Generic, Union, List, Tuple, Dict, Callable
+from typing import ClassVar, Generic, Union, List, Tuple, Dict, Callable, Literal
 
 import pytest
 
 from dataclass_wizard.type_def import T
 from dataclass_wizard.utils.typing_compat import get_origin, get_args
-from ...conftest import *
 
 
 @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, py310, py311, py312, py313, flake8
+envlist = py39, py310, py311, py312, py313, flake8
 
 [gh-actions]
 python =
@@ -8,9 +8,6 @@ python =
     3.11: py311
     3.10: py310
     3.9: py39
-    3.8: py38
-    3.7: py37
-    3.6: py36
 
 [testenv:flake8]
 basepython = python

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py36, py37, py38, py39, py310, py311, py312, flake8
+envlist = py36, py37, py38, py39, py310, py311, py312, py313, flake8
 
 [gh-actions]
 python =
+    3.13: py313
     3.12: py312
     3.11: py311
     3.10: py310


### PR DESCRIPTION
# `v0.27.0` - Drop support for PY 3.6, 3.7, and 3.8

## Changes

* This PR drops support/compatability for [Python versions that have reached EOL by now](https://devguide.python.org/versions/#unsupported-versions), which includes Python 3.6, 3.7, and (recently) 3.8.
* Add support for cyclic or "recursive" dataclasses: #138
* [Add test case to satisfy](https://github.com/rnag/dataclass-wizard/pull/139/commits/cf2e98cb75c75dc3e566ed0205637dbd4632e159) https://github.com/rnag/dataclass-wizard/issues/89

## Notes
* Closes #62
* Closes #109