### PR TITLE
v0.28.0: Minor Performance and QoL Change: Dynamically `exec` Dataclass Load and Dump Functions 

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,31 @@
 History
 =======
 
+0.28.0 (2024-11-15)
+-------------------
+
+**Features and Improvements**
+
+* Added :class:`TOMLWizard`.
+* Introduced new (pre-process) serializer hooks:
+    * :meth:`_pre_from_dict`
+    * :meth:`_pre_dict`
+* Added ``debug`` parameter to :meth:`JSONWizard.__init_subclass__`.
+* Added ``*.pyi`` stub files for better Type Hinting and Autocompletion in IDEs (e.g., PyCharm):
+    * :file:`abstractions.pyi`
+    * :file:`serial_json.pyi`
+* Introduced utility class :class:`FunctionBuilder` to help build and dynamically ``exec`` a function.
+* Documentation/tests on the new and updated features.
+
+**Changes**
+
+* The returned parser for a dataclass is now the original load/dump function itself (which takes a single argument)
+  rather than a :class:`Parser` instance.
+* Minor optimization and quality-of-life improvement: dynamically ``exec`` dataclass load and dump functions.
+* Improved performance: if a class defines a :meth:`from_dict` method - equivalent to :func:`fromdict` - and a :meth:`to_dict` method
+  - equivalent to :func:`asdict` - replace them with dynamically generated load/dump functions.
+* Deprecated the pre-process hook :meth:`DumpMixin.__pre_as_dict__`.
+
 0.27.0 (2024-11-10)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,7 @@ In addition to the ``JSONWizard``, here are a few extra Mixin_ classes that migh
 
 * `JSONListWizard`_ -- Extends ``JSONWizard`` to return `Container`_ -- instead of *list* -- objects where possible.
 * `JSONFileWizard`_ -- Makes it easier to convert dataclass instances from/to JSON files on a local drive.
+* `TOMLWizard`_ -- Provides support to convert dataclass instances to/from TOML.
 * `YAMLWizard`_ -- Provides support to convert dataclass instances to/from YAML, using the default ``PyYAML`` parser.
 
 
@@ -961,6 +962,7 @@ This package was created with Cookiecutter_ and the `rnag/cookiecutter-pypackage
 .. _`open an issue`: https://github.com/rnag/dataclass-wizard/issues
 .. _`JSONListWizard`: https://dataclass-wizard.readthedocs.io/en/latest/common_use_cases/wizard_mixins.html#jsonlistwizard
 .. _`JSONFileWizard`: https://dataclass-wizard.readthedocs.io/en/latest/common_use_cases/wizard_mixins.html#jsonfilewizard
+.. _`TOMLWizard`: https://dataclass-wizard.readthedocs.io/en/latest/common_use_cases/wizard_mixins.html#tomlwizard
 .. _`YAMLWizard`: https://dataclass-wizard.readthedocs.io/en/latest/common_use_cases/wizard_mixins.html#yamlwizard
 .. _`Container`: https://dataclass-wizard.readthedocs.io/en/latest/dataclass_wizard.html#dataclass_wizard.Container
 .. _`Supported Types`: https://dataclass-wizard.readthedocs.io/en/latest/overview.html#supported-types

--- a/dataclass_wizard/__init__.py
+++ b/dataclass_wizard/__init__.py
@@ -78,6 +78,7 @@ __all__ = [
     # Wizard Mixins
     'JSONListWizard',
     'JSONFileWizard',
+    'TOMLWizard',
     'YAMLWizard',
     # Helper serializer functions + meta config
     'fromlist',
@@ -104,7 +105,7 @@ from .models import (json_field, json_key, Container,
                      Pattern, DatePattern, TimePattern, DateTimePattern)
 from .property_wizard import property_wizard
 from .serial_json import JSONSerializable
-from .wizard_mixins import JSONListWizard, JSONFileWizard, YAMLWizard
+from .wizard_mixins import JSONListWizard, JSONFileWizard, TOMLWizard, YAMLWizard
 
 
 # Set up logging to ``/dev/null`` like a library is supposed to.

--- a/dataclass_wizard/abstractions.py
+++ b/dataclass_wizard/abstractions.py
@@ -119,7 +119,7 @@ class AbstractParser(ABC, Generic[T, TT]):
     # This is usually the underlying base type of the annotation (for example,
     # for `List[str]` it will be `list`), though in some cases this will be
     # the annotation itself.
-    base_type: T
+    base_type: type[T]
 
     def __contains__(self, item) -> bool:
         """

--- a/dataclass_wizard/abstractions.pyi
+++ b/dataclass_wizard/abstractions.pyi
@@ -376,5 +376,7 @@ class AbstractDumper(ABC):
         >>>     def __pre_as_dict__(self):
         >>>         self.my_str = self.my_str.swapcase()
 
+        @deprecated since v0.28.0. Use `_pre_dict()` instead - no need
+            to subclass from DumpMixin.
         """
         ...

--- a/dataclass_wizard/abstractions.pyi
+++ b/dataclass_wizard/abstractions.pyi
@@ -119,7 +119,7 @@ class AbstractParser(ABC, Generic[T, TT]):
     # This is usually the underlying base type of the annotation (for example,
     # for `list[str]` it will be `list`), though in some cases this will be
     # the annotation itself.
-    base_type: T
+    base_type: type[T]
 
     def __contains__(self, item) -> bool:
         """

--- a/dataclass_wizard/abstractions.pyi
+++ b/dataclass_wizard/abstractions.pyi
@@ -7,7 +7,7 @@ from dataclasses import dataclass, InitVar
 from datetime import datetime, time, date, timedelta
 from decimal import Decimal
 from typing import (
-    Any, Type, TypeVar, Union, List, Tuple, Dict, SupportsFloat, AnyStr,
+    Any, TypeVar, SupportsFloat, AnyStr,
     Text, Sequence, Iterable, Generic
 )
 
@@ -21,7 +21,7 @@ from .type_def import (
 # Create a generic variable that can be 'AbstractJSONWizard', or any subclass.
 W = TypeVar('W', bound='AbstractJSONWizard')
 
-FieldToParser = Dict[str, 'AbstractParser']
+FieldToParser = dict[str, 'AbstractParser']
 
 
 class AbstractJSONWizard(ABC):
@@ -38,7 +38,7 @@ class AbstractJSONWizard(ABC):
 
     @classmethod
     @abstractmethod
-    def from_json(cls: Type[W], string: AnyStr) -> Union[W, List[W]]:
+    def from_json(cls: type[W], string: AnyStr) -> W | list[W]:
         """
         Converts a JSON `string` to an instance of the dataclass, or a list of
         the dataclass instances.
@@ -46,14 +46,14 @@ class AbstractJSONWizard(ABC):
 
     @classmethod
     @abstractmethod
-    def from_list(cls: Type[W], o: ListOfJSONObject) -> List[W]:
+    def from_list(cls: type[W], o: ListOfJSONObject) -> list[W]:
         """
         Converts a Python `list` object to a list of the dataclass instances.
         """
 
     @classmethod
     @abstractmethod
-    def from_dict(cls: Type[W], o: JSONObject) -> W:
+    def from_dict(cls: type[W], o: JSONObject) -> W:
         """
         Converts a Python `dict` object to an instance of the dataclass.
         """
@@ -76,8 +76,8 @@ class AbstractJSONWizard(ABC):
 
     @classmethod
     @abstractmethod
-    def list_to_json(cls: Type[W],
-                     instances: List[W],
+    def list_to_json(cls: type[W],
+                     instances: list[W],
                      encoder: Encoder = json.dumps,
                      indent=None,
                      **encoder_kwargs) -> AnyStr:
@@ -108,7 +108,7 @@ class AbstractParser(ABC, Generic[T, TT]):
     # type `base_type`. This is primarily useful for resolving `ForwardRef`
     # types, where we need the globals of the class to resolve the underlying
     # type of the reference.
-    cls: InitVar[Type]
+    cls: InitVar[type]
 
     # This represents an optional Meta config that was specified for the main
     # dataclass. This is primarily useful to have so that we can merge this
@@ -117,7 +117,7 @@ class AbstractParser(ABC, Generic[T, TT]):
     extras: InitVar[Extras]
 
     # This is usually the underlying base type of the annotation (for example,
-    # for `List[str]` it will be `list`), though in some cases this will be
+    # for `list[str]` it will be `list`), though in some cases this will be
     # the annotation itself.
     base_type: T
 
@@ -163,7 +163,7 @@ class AbstractLoader(ABC):
 
     @staticmethod
     @abstractmethod
-    def load_after_type_check(o: Any, base_type: Type[T]) -> T:
+    def load_after_type_check(o: Any, base_type: type[T]) -> T:
         """
         Load an object `o`, after confirming that it is indeed of
         type `base_type`.
@@ -173,7 +173,7 @@ class AbstractLoader(ABC):
 
     @staticmethod
     @abstractmethod
-    def load_to_str(o: Union[Text, N, None], base_type: Type[str]) -> str:
+    def load_to_str(o: Text | N | None, base_type: type[str]) -> str:
         """
         Load a string or numeric type into a new object of type `base_type`
         (generally a sub-class of the :class:`str` type)
@@ -181,7 +181,7 @@ class AbstractLoader(ABC):
 
     @staticmethod
     @abstractmethod
-    def load_to_int(o: Union[str, int, bool, None], base_type: Type[N]) -> N:
+    def load_to_int(o: str | int | bool | None, base_type: type[N]) -> N:
         """
         Load a string or int into a new object of type `base_type`
         (generally a sub-class of the :class:`int` type)
@@ -189,7 +189,7 @@ class AbstractLoader(ABC):
 
     @staticmethod
     @abstractmethod
-    def load_to_float(o: Union[SupportsFloat, str], base_type: Type[N]) -> N:
+    def load_to_float(o: SupportsFloat | str, base_type: type[N]) -> N:
         """
         Load a string or float into a new object of type `base_type`
         (generally a sub-class of the :class:`float` type)
@@ -197,7 +197,7 @@ class AbstractLoader(ABC):
 
     @staticmethod
     @abstractmethod
-    def load_to_bool(o: Union[str, bool, N], _: Type[bool]) -> bool:
+    def load_to_bool(o: str | bool | N, _: type[bool]) -> bool:
         """
         Load a bool, string, or an numeric value into a new object of type
         `bool`.
@@ -208,7 +208,7 @@ class AbstractLoader(ABC):
 
     @staticmethod
     @abstractmethod
-    def load_to_enum(o: Union[AnyStr, N], base_type: Type[E]) -> E:
+    def load_to_enum(o: AnyStr | N, base_type: type[E]) -> E:
         """
         Load an object `o` into a new object of type `base_type` (generally a
         sub-class of the :class:`Enum` type)
@@ -216,7 +216,7 @@ class AbstractLoader(ABC):
 
     @staticmethod
     @abstractmethod
-    def load_to_uuid(o: Union[AnyStr, U], base_type: Type[U]) -> U:
+    def load_to_uuid(o: AnyStr | U, base_type: type[U]) -> U:
         """
         Load an object `o` into a new object of type `base_type` (generally a
         sub-class of the :class:`UUID` type)
@@ -225,7 +225,7 @@ class AbstractLoader(ABC):
     @staticmethod
     @abstractmethod
     def load_to_iterable(
-            o: Iterable, base_type: Type[LSQ],
+            o: Iterable, base_type: type[LSQ],
             elem_parser: AbstractParser) -> LSQ:
         """
         Load a list, set, frozenset or deque into a new object of type
@@ -236,8 +236,8 @@ class AbstractLoader(ABC):
     @staticmethod
     @abstractmethod
     def load_to_tuple(
-            o: Union[List, Tuple], base_type: Type[Tuple],
-            elem_parsers: Sequence[AbstractParser]) -> Tuple:
+            o: list | tuple, base_type: type[tuple],
+            elem_parsers: Sequence[AbstractParser]) -> tuple:
         """
         Load a list or tuple into a new object of type `base_type` (generally
         a :class:`tuple` or a sub-class of one)
@@ -246,9 +246,9 @@ class AbstractLoader(ABC):
     @staticmethod
     @abstractmethod
     def load_to_named_tuple(
-            o: Union[Dict, List, Tuple], base_type: Type[NT],
+            o: dict | list | tuple, base_type: type[NT],
             field_to_parser: FieldToParser,
-            field_parsers: List[AbstractParser]) -> NT:
+            field_parsers: list[AbstractParser]) -> NT:
         """
         Load a dictionary, list, or tuple to a `NamedTuple` sub-class
         """
@@ -256,7 +256,7 @@ class AbstractLoader(ABC):
     @staticmethod
     @abstractmethod
     def load_to_named_tuple_untyped(
-            o: Union[Dict, List, Tuple], base_type: Type[NT],
+            o: dict | list | tuple, base_type: type[NT],
             dict_parser: AbstractParser, list_parser: AbstractParser) -> NT:
         """
         Load a dictionary, list, or tuple to a (generally) un-typed
@@ -266,7 +266,7 @@ class AbstractLoader(ABC):
     @staticmethod
     @abstractmethod
     def load_to_dict(
-            o: Dict, base_type: Type[M],
+            o: dict, base_type: type[M],
             key_parser: AbstractParser,
             val_parser: AbstractParser) -> M:
         """
@@ -277,7 +277,7 @@ class AbstractLoader(ABC):
     @staticmethod
     @abstractmethod
     def load_to_defaultdict(
-            o: Dict, base_type: Type[DD],
+            o: dict, base_type: type[DD],
             default_factory: DefFactory,
             key_parser: AbstractParser,
             val_parser: AbstractParser) -> DD:
@@ -289,7 +289,7 @@ class AbstractLoader(ABC):
     @staticmethod
     @abstractmethod
     def load_to_typed_dict(
-            o: Dict, base_type: Type[M],
+            o: dict, base_type: type[M],
             key_to_parser: FieldToParser,
             required_keys: FrozenKeys,
             optional_keys: FrozenKeys) -> M:
@@ -301,7 +301,7 @@ class AbstractLoader(ABC):
 
     @staticmethod
     @abstractmethod
-    def load_to_decimal(o: N, base_type: Type[Decimal]) -> Decimal:
+    def load_to_decimal(o: N, base_type: type[Decimal]) -> Decimal:
         """
         Load an object `o` into a new object of type `base_type` (generally a
         :class:`Decimal` or a sub-class of one)
@@ -310,7 +310,7 @@ class AbstractLoader(ABC):
     @staticmethod
     @abstractmethod
     def load_to_datetime(
-            o: Union[str, N], base_type: Type[datetime]) -> datetime:
+            o: str | N, base_type: type[datetime]) -> datetime:
         """
         Load a string or number (int or float) into a new object of type
         `base_type` (generally a :class:`datetime` or a sub-class of one)
@@ -318,7 +318,7 @@ class AbstractLoader(ABC):
 
     @staticmethod
     @abstractmethod
-    def load_to_time(o: str, base_type: Type[time]) -> time:
+    def load_to_time(o: str, base_type: type[time]) -> time:
         """
         Load a string or number (int or float) into a new object of type
         `base_type` (generally a :class:`time` or a sub-class of one)
@@ -326,7 +326,7 @@ class AbstractLoader(ABC):
 
     @staticmethod
     @abstractmethod
-    def load_to_date(o: Union[str, N], base_type: Type[date]) -> date:
+    def load_to_date(o: str | N, base_type: type[date]) -> date:
         """
         Load a string or number (int or float) into a new object of type
         `base_type` (generally a :class:`date` or a sub-class of one)
@@ -335,7 +335,7 @@ class AbstractLoader(ABC):
     @staticmethod
     @abstractmethod
     def load_to_timedelta(
-            o: Union[str, N], base_type: Type[timedelta]) -> timedelta:
+            o: str | N, base_type: type[timedelta]) -> timedelta:
         """
         Load a string or number (int or float) into a new object of type
         `base_type` (generally a :class:`timedelta` or a sub-class of one)
@@ -343,8 +343,8 @@ class AbstractLoader(ABC):
 
     @classmethod
     @abstractmethod
-    def get_parser_for_annotation(cls, ann_type: Type[T],
-                                  base_cls: Type = None,
+    def get_parser_for_annotation(cls, ann_type: type[T],
+                                  base_cls: type = None,
                                   extras: Extras = None) -> AbstractParser:
         """
         Returns the Parser (dispatcher) for a given annotation type.
@@ -356,3 +356,25 @@ class AbstractLoader(ABC):
 
 class AbstractDumper(ABC):
     __slots__ = ()
+
+    def __pre_as_dict__(self):
+        """
+        Optional hook that runs before the dataclass instance is processed and
+        before it is converted to a dictionary object via :meth:`to_dict`.
+
+        To override this, subclasses need to extend from :class:`DumpMixIn`
+        and implement this method. A simple example is shown below:
+
+        >>> from dataclasses import dataclass
+        >>> from dataclass_wizard import JSONSerializable, DumpMixin
+        >>>
+        >>>
+        >>> @dataclass
+        >>> class MyClass(JSONSerializable, DumpMixin):
+        >>>     my_str: str
+        >>>
+        >>>     def __pre_as_dict__(self):
+        >>>         self.my_str = self.my_str.swapcase()
+
+        """
+        ...

--- a/dataclass_wizard/class_helper.py
+++ b/dataclass_wizard/class_helper.py
@@ -308,6 +308,11 @@ def dataclass_field_to_default(cls) -> Dict[str, Any]:
     return defaults
 
 
+def is_builtin_class(cls):
+    """Check if a class is a builtin in Python."""
+    return cls.__module__ == 'builtins'
+
+
 def create_new_class(
         class_or_instance, bases: Tuple[T, ...],
         suffix: Optional[str] = None, attr_dict=None) -> T:

--- a/dataclass_wizard/dumpers.py
+++ b/dataclass_wizard/dumpers.py
@@ -382,20 +382,14 @@ def dump_func_for_dataclass(cls: Type[T],
                     field_assignments.append(f"  result.append(('{json_field}',"
                                              f"asdict(obj.{field},dict_factory,hooks,config,cls_to_asdict)))")
 
-            cb.add_line('if exclude is None:')
-            cb.increase_indent()
-            cb.add_line(f'{'='.join(skip_field_assignments)}=False')
-            cb.decrease_indent()
-            cb.add_line('else:')
-            cb.increase_indent()
-            cb.add_line(';'.join(exclude_assignments_to_skip))
-            cb.decrease_indent()
+            with cb.if_block('exclude is None'):
+                cb.add_line(f'{'='.join(skip_field_assignments)}=False')
+            with cb.else_block():
+                cb.add_line(';'.join(exclude_assignments_to_skip))
 
             if skip_default_assignments:
-                cb.add_line('if skip_defaults:')
-                cb.increase_indent()
-                cb.add_lines(*skip_default_assignments)
-                cb.decrease_indent()
+                with cb.if_block('skip_defaults'):
+                    cb.add_lines(*skip_default_assignments)
 
             cb.add_lines(*field_assignments)
 

--- a/dataclass_wizard/dumpers.py
+++ b/dataclass_wizard/dumpers.py
@@ -251,6 +251,8 @@ def dump_func_for_dataclass(cls: Type[T],
                             nested_cls_to_dump_func: Dict[Type, Any] = None,
                             ) -> Callable[[T, Any, Any, Any], JSONObject]:
 
+    # TODO dynamically generate for multiple nested classes at once
+
     # Get the dumper for the class, or create a new one as needed.
     cls_dumper = get_dumper(cls)
 

--- a/dataclass_wizard/dumpers.py
+++ b/dataclass_wizard/dumpers.py
@@ -28,7 +28,7 @@ from .class_helper import (
     _CLASS_TO_DUMP_FUNC, setup_dump_config_for_cls_if_needed, get_meta,
     dataclass_field_to_load_parser,
 )
-from .constants import _DUMP_HOOKS, TAG
+from .constants import _DUMP_HOOKS, TAG, PY311_OR_ABOVE
 from .decorators import _alias
 from .log import LOG
 from .type_def import (
@@ -158,6 +158,10 @@ def setup_default_dumper(cls=DumpMixin):
     cls.register_dump_hook(NoneType, cls.dump_with_null)
     # Complex types
     cls.register_dump_hook(Enum, cls.dump_with_enum)
+    if PY311_OR_ABOVE:  # Register `IntEnum` and `StrEnum` (PY 3.11+)
+        from enum import IntEnum, StrEnum
+        cls.register_dump_hook(IntEnum, cls.dump_with_enum)
+        cls.register_dump_hook(StrEnum, cls.dump_with_enum)
     cls.register_dump_hook(UUID, cls.dump_with_uuid)
     cls.register_dump_hook(set, cls.dump_with_iterable)
     cls.register_dump_hook(frozenset, cls.dump_with_iterable)

--- a/dataclass_wizard/dumpers.py
+++ b/dataclass_wizard/dumpers.py
@@ -331,10 +331,10 @@ def dump_func_for_dataclass(cls: Type[T],
 
     # Code for `cls_asdict`
     with cb.function('cls_asdict',
-                ['obj:T',
-                     'dict_factory=dict',
-                     "exclude:'list[str]|None'=None",
-                     f'skip_defaults:bool={meta.skip_defaults}'],
+                     ['obj:T',
+                      'dict_factory=dict',
+                      "exclude:'list[str]|None'=None",
+                      f'skip_defaults:bool={meta.skip_defaults}'],
                      return_type='JSONObject'):
 
         _pre_as_dict_method = getattr(cls_dumper, '__pre_as_dict__', None)
@@ -348,7 +348,7 @@ def dump_func_for_dataclass(cls: Type[T],
         if field_names:
 
             skip_field_assignments = []
-            exclude_assignments_to_skip = []
+            exclude_assignments = []
             skip_default_assignments = []
             field_assignments = []
 
@@ -358,7 +358,7 @@ def dump_func_for_dataclass(cls: Type[T],
                 default_value = f'_default_{i}'
 
                 skip_field_assignments.append(skip_field)
-                exclude_assignments_to_skip.append(
+                exclude_assignments.append(
                     f'{skip_field}={field!r} in exclude'
                 )
                 if field in field_to_default:
@@ -385,7 +385,7 @@ def dump_func_for_dataclass(cls: Type[T],
             with cb.if_block('exclude is None'):
                 cb.add_line(f'{'='.join(skip_field_assignments)}=False')
             with cb.else_block():
-                cb.add_line(';'.join(exclude_assignments_to_skip))
+                cb.add_line(';'.join(exclude_assignments))
 
             if skip_default_assignments:
                 with cb.if_block('skip_defaults'):
@@ -403,7 +403,9 @@ def dump_func_for_dataclass(cls: Type[T],
             cb.add_line("return dict_factory(result)")
 
     # Compile the code into a dynamic string
-    cls_asdict = cb.create_functions(locals=_locals, globals=_globals)
+    functions = cb.create_functions(locals=_locals, globals=_globals)
+
+    cls_asdict = functions['cls_asdict']
 
     asdict_func = cls_asdict
 

--- a/dataclass_wizard/dumpers.py
+++ b/dataclass_wizard/dumpers.py
@@ -383,7 +383,7 @@ def dump_func_for_dataclass(cls: Type[T],
                                              f"asdict(obj.{field},dict_factory,hooks,config,cls_to_asdict)))")
 
             with cb.if_block('exclude is None'):
-                cb.add_line(f'{'='.join(skip_field_assignments)}=False')
+                cb.add_line('='.join(skip_field_assignments) + '=False')
             with cb.else_block():
                 cb.add_line(';'.join(exclude_assignments))
 

--- a/dataclass_wizard/dumpers.py
+++ b/dataclass_wizard/dumpers.py
@@ -28,7 +28,7 @@ from .class_helper import (
     _CLASS_TO_DUMP_FUNC, setup_dump_config_for_cls_if_needed, get_meta,
     dataclass_field_to_load_parser,
 )
-from .constants import _DUMP_HOOKS, TAG, PY311_OR_ABOVE
+from .constants import _DUMP_HOOKS, TAG
 from .decorators import _alias
 from .log import LOG
 from .type_def import (
@@ -158,10 +158,6 @@ def setup_default_dumper(cls=DumpMixin):
     cls.register_dump_hook(NoneType, cls.dump_with_null)
     # Complex types
     cls.register_dump_hook(Enum, cls.dump_with_enum)
-    if PY311_OR_ABOVE:  # Register `IntEnum` and `StrEnum` (PY 3.11+)
-        from enum import IntEnum, StrEnum
-        cls.register_dump_hook(IntEnum, cls.dump_with_enum)
-        cls.register_dump_hook(StrEnum, cls.dump_with_enum)
     cls.register_dump_hook(UUID, cls.dump_with_uuid)
     cls.register_dump_hook(set, cls.dump_with_iterable)
     cls.register_dump_hook(frozenset, cls.dump_with_iterable)

--- a/dataclass_wizard/dumpers.py
+++ b/dataclass_wizard/dumpers.py
@@ -423,7 +423,9 @@ def dump_func_for_dataclass(cls: Type[T],
     # In any case, save the dump function for the class, so we don't need to
     # run this logic each time.
     if is_main_class:
-        if hasattr(cls, 'to_dict'):
+        # Check if the class has a `to_dict`, and it's
+        # equivalent to `asdict`.
+        if getattr(cls, 'to_dict', None) is asdict:
             _set_new_attribute(cls, 'to_dict', asdict_func)
         _CLASS_TO_DUMP_FUNC[cls] = asdict_func
     else:

--- a/dataclass_wizard/errors.py
+++ b/dataclass_wizard/errors.py
@@ -2,13 +2,34 @@ import json
 from abc import ABC, abstractmethod
 from dataclasses import Field, MISSING
 from typing import (Any, Type, Dict, Tuple, ClassVar,
-                    Optional, Union, Iterable)
+                    Optional, Union, Iterable, Callable)
 
 from .utils.string_conv import normalize
 
 
 # added as we can't import from `type_def`, as we run into a circular import.
 JSONObject = Dict[str, Any]
+
+
+def show_deprecation_warning(
+    fn: Callable,
+    reason: str,
+    fmt: str = "Deprecated function {name} ({reason})."
+) -> None:
+    """
+    Display a deprecation warning for a given function.
+
+    @param fn: Function which is deprecated.
+    @param reason: Reason for the deprecation.
+    @param fmt: Format string for the name/reason.
+    """
+    import warnings
+    warnings.simplefilter('always', DeprecationWarning)
+    warnings.warn(
+        fmt.format(name=fn.__name__, reason=reason),
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
 
 
 class JSONWizardError(ABC, Exception):

--- a/dataclass_wizard/errors.py
+++ b/dataclass_wizard/errors.py
@@ -128,7 +128,7 @@ class MissingFields(JSONWizardError):
                  obj: JSONObject,
                  cls: Type,
                  cls_kwargs: JSONObject,
-                 cls_fields: Tuple[Field], **kwargs):
+                 cls_fields: Tuple[Field, ...], **kwargs):
 
         super().__init__()
 
@@ -199,7 +199,7 @@ class UnknownJSONKey(JSONWizardError):
                  json_key: str,
                  obj: JSONObject,
                  cls: Type,
-                 cls_fields: Tuple[Field], **kwargs):
+                 cls_fields: Tuple[Field, ...], **kwargs):
         super().__init__()
 
         self.json_key = json_key

--- a/dataclass_wizard/lazy_imports.py
+++ b/dataclass_wizard/lazy_imports.py
@@ -5,6 +5,7 @@ Lazy Import definitions. Generally, these imports will be available when any
   $ pip install dataclass-wizard[timedelta]
 """
 
+from .constants import PY311_OR_ABOVE
 from .utils.lazy_loader import LazyLoader
 
 
@@ -13,3 +14,13 @@ pytimeparse = LazyLoader(globals(), 'pytimeparse', 'timedelta')
 
 # PyYAML: to add support for (de)serializing YAML data to dataclass instances
 yaml = LazyLoader(globals(), 'yaml', 'yaml', local_name='PyYAML')
+
+# Tomli -or- tomllib (PY 3.11+): to add support for (de)serializing TOML
+# data to dataclass instances
+if PY311_OR_ABOVE:
+    import tomllib as toml
+else:
+    toml = LazyLoader(globals(), 'tomli', 'toml', local_name='tomli')
+
+# Tomli-W: to add support for serializing dataclass instances to TOML
+toml_w = LazyLoader(globals(), 'tomli_w', 'toml', local_name='tomli-w')

--- a/dataclass_wizard/loaders.py
+++ b/dataclass_wizard/loaders.py
@@ -307,6 +307,8 @@ class LoadMixin(AbstractLoader, BaseLoadHook):
                             )
                         else:  # else, logic is same as normal
                             base_type: 'type[T]'
+                            # return a dynamically generated `fromdict`
+                            # for the `cls` (base_type)
                             return load_func_for_dataclass(
                                 base_type,
                                 is_main_class=False,
@@ -648,6 +650,11 @@ def load_func_for_dataclass(
     fn_gen = FunctionBuilder()
 
     with fn_gen.function('cls_fromdict', ['o']):
+
+        _pre_from_dict_method = getattr(cls, '_pre_from_dict', None)
+        if _pre_from_dict_method is not None:
+            _locals['__pre_from_dict__'] = _pre_from_dict_method
+            fn_gen.add_line('o = __pre_from_dict__(o)')
 
         # Need to create a separate dictionary to copy over the constructor
         # args, as we don't want to mutate the original dictionary object.

--- a/dataclass_wizard/loaders.py
+++ b/dataclass_wizard/loaders.py
@@ -747,7 +747,10 @@ def load_func_for_dataclass(
     # Save the load function for the main dataclass, so we don't need to run
     # this logic each time.
     if is_main_class:
-        if hasattr(cls, 'from_dict'):
+        # Check if the class has a `from_dict`, and it's
+        # a class method bound to `fromdict`.
+        if ((from_dict := getattr(cls, 'from_dict', None)) is not None
+                and getattr(from_dict, '__func__', None) is fromdict):
             _set_new_attribute(cls, 'from_dict', cls_fromdict)
         _CLASS_TO_LOAD_FUNC[cls] = cls_fromdict
 

--- a/dataclass_wizard/loaders.py
+++ b/dataclass_wizard/loaders.py
@@ -587,6 +587,8 @@ def load_func_for_dataclass(
         config: Optional[META] = None,
 ) -> Callable[[JSONObject], T]:
 
+    # TODO dynamically generate for multiple nested classes at once
+
     # Get the loader for the class, or create a new one as needed.
     cls_loader = get_loader(cls)
 

--- a/dataclass_wizard/loaders.py
+++ b/dataclass_wizard/loaders.py
@@ -32,7 +32,9 @@ from .type_def import (
     PyRequired, PyNotRequired,
     M, N, T, E, U, DD, LSQ, NT
 )
-from .utils.code_builder import CodeBuilder
+from .utils.function_builder import FunctionBuilder
+# noinspection PyProtectedMember
+from .utils.dataclass_compat import _set_new_attribute
 from .utils.string_conv import to_snake_case
 from .utils.type_conv import (
     as_bool, as_str, as_datetime, as_date, as_time, as_int, as_timedelta
@@ -589,6 +591,7 @@ def load_func_for_dataclass(
 
     # TODO dynamically generate for multiple nested classes at once
 
+    # Tuple describing the fields of this dataclass.
     cls_fields = dataclass_fields(cls)
 
     # Get the loader for the class, or create a new one as needed.
@@ -628,41 +631,38 @@ def load_func_for_dataclass(
 
     _locals = {
         'cls': cls,
-        'config': config,
         'py_case': cls_loader.transform_json_field,
         'field_to_parser': field_to_parser,
         'json_to_field': json_to_field,
         'ExplicitNull': ExplicitNull,
     }
 
-    # TODO Unsure if dataclasses uses globals()?
     _globals = {
         'cls_fields': cls_fields,
         'LOG': LOG,
         'MissingData': MissingData,
         'MissingFields': MissingFields,
-        'UnknownJSONKey': UnknownJSONKey,
     }
 
-    # Initialize the CodeBuilder
-    cb = CodeBuilder()
+    # Initialize the FuncBuilder
+    fn_gen = FunctionBuilder()
 
-    with cb.function('cls_fromdict', ['o']):
+    with fn_gen.function('cls_fromdict', ['o']):
 
         # Need to create a separate dictionary to copy over the constructor
         # args, as we don't want to mutate the original dictionary object.
-        cb.add_line('init_kwargs = {}')
+        fn_gen.add_line('init_kwargs = {}')
         # This try-block is here in case the object `o` is None.
-        with cb.try_block():
+        with fn_gen.try_():
             # Loop over the dictionary object
-            with cb.for_block('json_key in o'):
+            with fn_gen.for_('json_key in o'):
 
-                with cb.try_block():
+                with fn_gen.try_():
                     # Get the resolved dataclass field name
-                    cb.add_line("field_name = json_to_field[json_key]")
+                    fn_gen.add_line("field = json_to_field[json_key]")
 
-                with cb.except_block(KeyError):
-                    cb.add_line('# Lookup Field for JSON Key')
+                with fn_gen.except_(KeyError):
+                    fn_gen.add_line('# Lookup Field for JSON Key')
                     # Determines the dataclass field which a JSON key should map to.
                     # Note this logic only runs the initial time, i.e. the first time
                     # we encounter the key in a JSON object.
@@ -672,65 +672,66 @@ def load_func_for_dataclass(
                     #   config for the class.
 
                     # Short path: an identical-cased field name exists for the JSON key
-                    with cb.if_block('json_key in field_to_parser'):
-                        cb.add_line("field_name = json_to_field[json_key] = json_key")
+                    with fn_gen.if_('json_key in field_to_parser'):
+                        fn_gen.add_line("field = json_to_field[json_key] = json_key")
 
-                    with cb.else_block():
+                    with fn_gen.else_():
                         # Transform JSON field name (typically camel-cased) to the
                         # snake-cased variant which is convention in Python.
-                        cb.add_line("py_field = py_case(json_key)")
+                        fn_gen.add_line("py_field = py_case(json_key)")
 
-                        with cb.try_block():
+                        with fn_gen.try_():
                             # Do a case-insensitive lookup of the dataclass field, and
                             # cache the mapping, so we have it for next time
-                            cb.add_line("field_name "
-                                        "= json_to_field[json_key] "
-                                        "= field_to_parser.get_key(py_field)")
+                            fn_gen.add_line("field "
+                                            "= json_to_field[json_key] "
+                                            "= field_to_parser.get_key(py_field)")
 
-                        with cb.except_block(KeyError):
+                        with fn_gen.except_(KeyError):
                             # Else, we see an unknown field in the dictionary object
-                            cb.add_line("field_name = json_to_field[json_key] = ExplicitNull")
-                            cb.add_line("LOG.warning('JSON field %r missing from dataclass schema, "
-                                        "class=%r, parsed field=%r',json_key,cls,py_field)")
+                            fn_gen.add_line("field = json_to_field[json_key] = ExplicitNull")
+                            fn_gen.add_line("LOG.warning('JSON field %r missing from dataclass schema, "
+                                            "class=%r, parsed field=%r',json_key,cls,py_field)")
                             # Raise an error here (if needed)
                             if meta.raise_on_unknown_json_key:
-                                cb.add_line("raise UnknownJSONKey(json_key, o, cls, cls_fields) from None")
+                                _globals['UnknownJSONKey'] = UnknownJSONKey
+                                fn_gen.add_line("raise UnknownJSONKey(json_key, o, cls, cls_fields) from None")
 
                 # Exclude JSON keys that don't map to any fields.
-                with cb.if_block('field_name is not ExplicitNull'):
+                with fn_gen.if_('field is not ExplicitNull'):
 
-                    with cb.try_block():
+                    with fn_gen.try_():
                         # Note: pass the original cased field to the class constructor;
                         # don't use the lowercase result from `py_case`
-                        cb.add_line("init_kwargs[field_name] = field_to_parser[field_name](o[json_key])")
+                        fn_gen.add_line("init_kwargs[field] = field_to_parser[field](o[json_key])")
 
-                    with cb.except_block(ParseError, 'e'):
+                    with fn_gen.except_(ParseError, 'e'):
                         # We run into a parsing error while loading the field value;
                         # Add additional info on the Exception object before re-raising it.
-                        cb.add_line("e.class_name, e.field_name, e.json_object = cls, field_name, o")
-                        cb.add_line("raise")
+                        fn_gen.add_line("e.class_name, e.field_name, e.json_object = cls, field, o")
+                        fn_gen.add_line("raise")
 
-        with cb.except_block(TypeError):
+        with fn_gen.except_(TypeError):
             # If the object `o` is None, then raise an error with the relevant info included.
-            with cb.if_block('o is None'):
-                cb.add_line("raise MissingData(cls) from None")
+            with fn_gen.if_('o is None'):
+                fn_gen.add_line("raise MissingData(cls) from None")
             # Check if the object `o` is some other type than what we expect -
             # for example, we could be passed in a `list` type instead.
-            with cb.if_block('not isinstance(o, dict)'):
-                cb.add_line("e = TypeError('Incorrect type for field')")
-                cb.add_line("raise ParseError(e, o, dict, cls, desired_type=dict) from None")
+            with fn_gen.if_('not isinstance(o, dict)'):
+                fn_gen.add_line("e = TypeError('Incorrect type for field')")
+                fn_gen.add_line("raise ParseError(e, o, dict, cls, desired_type=dict) from None")
 
             # Else, just re-raise the error.
-            cb.add_line("raise")
+            fn_gen.add_line("raise")
 
         # Now pass the arguments to the constructor method, and return the new dataclass instance.
         # If there are any missing fields, we raise them here.
-        with cb.try_block():
-            cb.add_line("return cls(**init_kwargs)")
-        with cb.except_block(TypeError, 'e'):
-            cb.add_line("raise MissingFields(e, o, cls, init_kwargs, cls_fields) from None")
+        with fn_gen.try_():
+            fn_gen.add_line("return cls(**init_kwargs)")
+        with fn_gen.except_(TypeError, 'e'):
+            fn_gen.add_line("raise MissingFields(e, o, cls, init_kwargs, cls_fields) from None")
 
-    functions = cb.create_functions(
+    functions = fn_gen.create_functions(
         locals=_locals, globals=_globals
     )
 
@@ -739,6 +740,8 @@ def load_func_for_dataclass(
     # Save the load function for the main dataclass, so we don't need to run
     # this logic each time.
     if is_main_class:
+        if hasattr(cls, 'from_dict'):
+            _set_new_attribute(cls, 'from_dict', cls_fromdict)
         _CLASS_TO_LOAD_FUNC[cls] = cls_fromdict
 
     return cls_fromdict

--- a/dataclass_wizard/loaders.py
+++ b/dataclass_wizard/loaders.py
@@ -20,7 +20,7 @@ from .class_helper import (
     dataclass_field_to_load_parser, json_field_to_dataclass_field,
     _CLASS_TO_LOAD_FUNC, dataclass_fields, get_meta, is_subclass_safe,
 )
-from .constants import _LOAD_HOOKS, SINGLE_ARG_ALIAS, IDENTITY, PY311_OR_ABOVE
+from .constants import _LOAD_HOOKS, SINGLE_ARG_ALIAS, IDENTITY
 from .decorators import _alias, _single_arg_alias, resolve_alias_func, _identity
 from .errors import (ParseError, MissingFields, UnknownJSONKey,
                      MissingData, RecursiveClassError)
@@ -496,10 +496,6 @@ def setup_default_loader(cls=LoadMixin):
     cls.register_load_hook(NoneType, cls.default_load_to)
     # Complex types
     cls.register_load_hook(Enum, cls.load_to_enum)
-    if PY311_OR_ABOVE:  # Register `IntEnum` and `StrEnum` (PY 3.11+)
-        from enum import IntEnum, StrEnum
-        cls.register_load_hook(IntEnum, cls.load_to_enum)
-        cls.register_load_hook(StrEnum, cls.load_to_enum)
     cls.register_load_hook(UUID, cls.load_to_uuid)
     cls.register_load_hook(set, cls.load_to_iterable)
     cls.register_load_hook(frozenset, cls.load_to_iterable)

--- a/dataclass_wizard/loaders.py
+++ b/dataclass_wizard/loaders.py
@@ -20,7 +20,7 @@ from .class_helper import (
     dataclass_field_to_load_parser, json_field_to_dataclass_field,
     _CLASS_TO_LOAD_FUNC, dataclass_fields, get_meta, is_subclass_safe,
 )
-from .constants import _LOAD_HOOKS, SINGLE_ARG_ALIAS, IDENTITY
+from .constants import _LOAD_HOOKS, SINGLE_ARG_ALIAS, IDENTITY, PY311_OR_ABOVE
 from .decorators import _alias, _single_arg_alias, resolve_alias_func, _identity
 from .errors import (ParseError, MissingFields, UnknownJSONKey,
                      MissingData, RecursiveClassError)
@@ -496,6 +496,10 @@ def setup_default_loader(cls=LoadMixin):
     cls.register_load_hook(NoneType, cls.default_load_to)
     # Complex types
     cls.register_load_hook(Enum, cls.load_to_enum)
+    if PY311_OR_ABOVE:  # Register `IntEnum` and `StrEnum` (PY 3.11+)
+        from enum import IntEnum, StrEnum
+        cls.register_load_hook(IntEnum, cls.load_to_enum)
+        cls.register_load_hook(StrEnum, cls.load_to_enum)
     cls.register_load_hook(UUID, cls.load_to_uuid)
     cls.register_load_hook(set, cls.load_to_iterable)
     cls.register_load_hook(frozenset, cls.load_to_iterable)

--- a/dataclass_wizard/serial_json.py
+++ b/dataclass_wizard/serial_json.py
@@ -1,8 +1,9 @@
 import json
+import logging
 from typing import Type, List, Union, AnyStr
 
 from .abstractions import AbstractJSONWizard, W
-from .bases_meta import BaseJSONWizardMeta
+from .bases_meta import BaseJSONWizardMeta, LoadMeta
 from .class_helper import call_meta_initializer_if_needed
 from .decorators import _alias
 from .dumpers import asdict
@@ -96,12 +97,14 @@ class JSONSerializable(AbstractJSONWizard):
         return encoder(list_of_dict, **encoder_kwargs)
 
     # noinspection PyShadowingBuiltins
-    def __init_subclass__(cls, str=True):
+    def __init_subclass__(cls, str=True, debug=False):
         """
         Checks for optional settings and flags that may be passed in by the
         sub-class, and calls the Meta initializer when :class:`Meta` is sub-classed.
 
         :param str: True to add a default `__str__` method to the subclass.
+        :param debug: True to enable debug mode and setup logging, so that
+          this library's DEBUG (and above) log messages are visible.
         """
         super().__init_subclass__()
         # Calls the Meta initializer when inner :class:`Meta` is sub-classed.
@@ -109,6 +112,9 @@ class JSONSerializable(AbstractJSONWizard):
         # Add a `__str__` method to the subclass, if needed
         if str:
             _set_new_attribute(cls, '__str__', _str_fn())
+        if debug:
+            logging.basicConfig(level='DEBUG')
+            LoadMeta(debug_enabled=True).bind_to(cls)
 
 
 def _str_fn():

--- a/dataclass_wizard/serial_json.pyi
+++ b/dataclass_wizard/serial_json.pyi
@@ -34,6 +34,60 @@ class JSONSerializable(AbstractJSONWizard):
             ...
 
     @classmethod
+    def _pre_from_dict(cls: Type[W], o: JSONObject) -> JSONObject:
+        """
+        Optional hook that runs before the dataclass instance is
+        loaded, and before it is converted from a dictionary object
+        via :meth:`from_dict`.
+
+        To override this, subclasses need to implement this method.
+        A simple example is shown below:
+
+        >>> from dataclasses import dataclass
+        >>> from dataclass_wizard import JSONWizard
+        >>> from dataclass_wizard.type_def import JSONObject
+        >>>
+        >>>
+        >>> @dataclass
+        >>> class MyClass(JSONWizard):
+        >>>     a_bool: bool
+        >>>
+        >>>     @classmethod
+        >>>     def _pre_from_dict(cls, o: JSONObject) -> JSONObject:
+        >>>         # o = o.copy()  # Copying the `dict` object is optional
+        >>>         o['a_bool'] = True  # Add a new key/value pair
+        >>>         return o
+        >>>
+        >>> c = MyClass.from_dict({})
+        >>> assert c == MyClass(a_bool=True)
+        """
+        ...
+
+    def _pre_dict(self):
+        # noinspection PyDunderSlots, PyUnresolvedReferences
+        """
+                Optional hook that runs before the dataclass instance is processed and
+                before it is converted to a dictionary object via :meth:`to_dict`.
+
+                To override this, subclasses need to extend from :class:`DumpMixIn`
+                and implement this method. A simple example is shown below:
+
+                >>> from dataclasses import dataclass
+                >>> from dataclass_wizard import JSONWizard
+                >>>
+                >>>
+                >>> @dataclass
+                >>> class MyClass(JSONWizard):
+                >>>     my_str: str
+                >>>
+                >>>     def _pre_dict(self):
+                >>>         self.my_str = self.my_str.swapcase()
+                >>>
+                >>> assert MyClass('test').to_dict() == {'myStr': 'TEST'}
+                """
+        ...
+
+    @classmethod
     def from_json(cls: Type[W], string: AnyStr, *,
                   decoder: Decoder = json.loads,
                   **decoder_kwargs) -> Union[W, List[W]]:
@@ -108,11 +162,13 @@ class JSONSerializable(AbstractJSONWizard):
         ...
 
     # noinspection PyShadowingBuiltins
-    def __init_subclass__(cls, str=True):
+    def __init_subclass__(cls, str=True, debug=False):
         """
         Checks for optional settings and flags that may be passed in by the
         sub-class, and calls the Meta initializer when :class:`Meta` is sub-classed.
 
         :param str: True to add a default `__str__` method to the subclass.
+        :param debug: True to enable debug mode and setup logging, so that
+          this library's DEBUG (and above) log messages are visible.
         """
         ...

--- a/dataclass_wizard/serial_json.pyi
+++ b/dataclass_wizard/serial_json.pyi
@@ -1,5 +1,5 @@
 import json
-from typing import Type, List, Union, AnyStr, Sequence
+from typing import Type, List, Union, AnyStr, Collection
 
 from .abstractions import AbstractJSONWizard, W
 from .bases_meta import BaseJSONWizardMeta
@@ -62,7 +62,7 @@ class JSONSerializable(AbstractJSONWizard):
     def to_dict(self: W,
                 *,
                 dict_factory=dict,
-                exclude: Sequence[str] | None = None,
+                exclude: Collection[str] | None = None,
                 skip_defaults: bool | None = None,
                 ) -> JSONObject:
         """

--- a/dataclass_wizard/serial_json.pyi
+++ b/dataclass_wizard/serial_json.pyi
@@ -1,5 +1,5 @@
 import json
-from typing import Type, List, Union, AnyStr
+from typing import Type, List, Union, AnyStr, Sequence
 
 from .abstractions import AbstractJSONWizard, W
 from .bases_meta import BaseJSONWizardMeta
@@ -59,10 +59,31 @@ class JSONSerializable(AbstractJSONWizard):
         # alias: fromdict(cls, o)
         ...
 
-    def to_dict(self: W) -> JSONObject:
+    def to_dict(self: W,
+                *,
+                dict_factory=dict,
+                exclude: Sequence[str] | None = None,
+                skip_defaults: bool | None = None,
+                ) -> JSONObject:
         """
         Converts the dataclass instance to a Python dictionary object that is
         JSON serializable.
+
+        Example usage:
+
+          @dataclass
+          class C(JSONWizard):
+              x: int
+              y: int
+              z: bool = True
+
+          c = C(1, 2, True)
+          assert c.to_dict(skip_defaults=True) == {'x': 1, 'y': 2}
+
+        If given, 'dict_factory' will be used instead of built-in dict.
+        The function applies recursively to field values that are
+        dataclass instances. This will also look into built-in containers:
+        tuples, lists, and dicts.
         """
         # alias: asdict(self)
         ...

--- a/dataclass_wizard/serial_json.pyi
+++ b/dataclass_wizard/serial_json.pyi
@@ -1,0 +1,97 @@
+import json
+from typing import Type, List, Union, AnyStr
+
+from .abstractions import AbstractJSONWizard, W
+from .bases_meta import BaseJSONWizardMeta
+from .type_def import Decoder, Encoder, JSONObject, ListOfJSONObject
+
+
+# A handy alias in case it comes in useful to anyone :)
+JSONWizard = JSONSerializable
+
+
+class JSONSerializable(AbstractJSONWizard):
+    """
+    Mixin class to allow a `dataclass` sub-class to be easily converted
+    to and from JSON.
+
+    """
+    __slots__ = ()
+
+    class Meta(BaseJSONWizardMeta):
+        """
+        Inner meta class that can be extended by sub-classes for additional
+        customization with the JSON load / dump process.
+        """
+        __slots__ = ()
+
+        # Class attribute to enable detection of the class type.
+        __is_inner_meta__ = True
+
+        def __init_subclass__(cls):
+            # Set the `__init_subclass__` method here, so we can ensure it
+            # doesn't run for the `JSONSerializable.Meta` class.
+            ...
+
+    @classmethod
+    def from_json(cls: Type[W], string: AnyStr, *,
+                  decoder: Decoder = json.loads,
+                  **decoder_kwargs) -> Union[W, List[W]]:
+        """
+        Converts a JSON `string` to an instance of the dataclass, or a list of
+        the dataclass instances.
+        """
+        ...
+
+    @classmethod
+    def from_list(cls: Type[W], o: ListOfJSONObject) -> List[W]:
+        """
+        Converts a Python `list` object to a list of the dataclass instances.
+        """
+        # alias: fromlist(cls, o)
+        ...
+
+    @classmethod
+    def from_dict(cls: Type[W], o: JSONObject) -> W:
+        """
+        Converts a Python `dict` object to an instance of the dataclass.
+        """
+        # alias: fromdict(cls, o)
+        ...
+
+    def to_dict(self: W) -> JSONObject:
+        """
+        Converts the dataclass instance to a Python dictionary object that is
+        JSON serializable.
+        """
+        # alias: asdict(self)
+        ...
+
+    def to_json(self: W, *,
+                encoder: Encoder = json.dumps,
+                **encoder_kwargs) -> AnyStr:
+        """
+        Converts the dataclass instance to a JSON `string` representation.
+        """
+        ...
+
+    @classmethod
+    def list_to_json(cls: Type[W],
+                     instances: List[W],
+                     encoder: Encoder = json.dumps,
+                     **encoder_kwargs) -> AnyStr:
+        """
+        Converts a ``list`` of dataclass instances to a JSON `string`
+        representation.
+        """
+        ...
+
+    # noinspection PyShadowingBuiltins
+    def __init_subclass__(cls, str=True):
+        """
+        Checks for optional settings and flags that may be passed in by the
+        sub-class, and calls the Meta initializer when :class:`Meta` is sub-classed.
+
+        :param str: True to add a default `__str__` method to the subclass.
+        """
+        ...

--- a/dataclass_wizard/type_def.py
+++ b/dataclass_wizard/type_def.py
@@ -145,17 +145,24 @@ else:
 FREF = TypeVar('FREF', str, PyForwardRef)
 
 
-# Create our own "nullish" type for explicit type assertions
 class ExplicitNullType:
-    __slots__ = ()
+    __slots__ = ()  # Saves memory by preventing the creation of instance dictionaries
+
+    _instance = None  # Class-level instance variable for singleton control
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(ExplicitNullType, cls).__new__(cls)
+        return cls._instance
 
     def __bool__(self):
         return False
 
     def __repr__(self):
-        return self.__class__.__qualname__
+        return '<ExplicitNull>'
 
 
+# Create the singleton instance
 ExplicitNull = ExplicitNullType()
 
 

--- a/dataclass_wizard/type_def.py
+++ b/dataclass_wizard/type_def.py
@@ -16,6 +16,7 @@ __all__ = [
     'JSONObject',
     'ListOfJSONObject',
     'JSONValue',
+    'ParseFloat',
     'Encoder',
     'FileEncoder',
     'Decoder',
@@ -164,6 +165,9 @@ class ExplicitNullType:
 
 # Create the singleton instance
 ExplicitNull = ExplicitNullType()
+
+# Type annotations
+ParseFloat = Callable[[str], Any]
 
 
 class Encoder(PyProtocol):

--- a/dataclass_wizard/type_def.py
+++ b/dataclass_wizard/type_def.py
@@ -173,6 +173,8 @@ class Encoder(PyProtocol):
     """
 
     def __call__(self, obj: Union[JSONObject, JSONList],
+                 /,
+                 *args,
                  **kwargs) -> AnyStr:
         ...
 

--- a/dataclass_wizard/utils/code_builder.py
+++ b/dataclass_wizard/utils/code_builder.py
@@ -1,0 +1,100 @@
+import types
+import logging
+from dataclasses import MISSING
+from timeit import timeit
+
+# Set up logging
+logging.basicConfig(level=logging.INFO, format='%(message)s')
+
+
+class CodeBuilder:
+    def __init__(self):
+        self.functions = {}
+        self.namespace = {}
+        self.indent_level = 0
+
+    def add_function(self, name: str, args: list, return_type=None):
+        """Start a new function definition with optional return type."""
+        self.current_function = {"name": name, "args": args, "body": [], "return_type": return_type}
+        # self.add_line(f"def {name}({', '.join(args)})")  # Add function header
+        if return_type:
+            self.add_line(f"    # Return type: {return_type}")  # Log return type in the comments
+        self.indent_level = 2  # Indent level for function body
+
+    def add_line(self, line: str):
+        """Add a line to the current function's body with proper indentation."""
+        indent = '  ' * self.indent_level
+        self.current_function["body"].append(f"{indent}{line}")
+
+    def increase_indent(self):
+        """Increase indentation level for nested code."""
+        self.indent_level += 1
+
+    def decrease_indent(self):
+        """Decrease indentation level."""
+        if self.indent_level > 1:
+            self.indent_level -= 1
+
+    def finalize_function(self):
+        """Finalize the function code and add to the list of functions."""
+        # Add the function body and don't re-add the function definition
+        func_code = '\n'.join(self.current_function["body"])
+        self.functions[self.current_function["name"]] = ({"args": self.current_function["args"], "code": func_code})
+        self.current_function = None  # Reset current function
+
+    def compile_with_types(self, *, globals=None, locals=None,
+                           return_type=MISSING
+                           ):
+        """Create functions by compiling the code."""
+        # Note that we may mutate locals. Callers beware!
+        # The only callers are internal to this module, so no
+        # worries about external callers.
+        if locals is None:
+            locals = {}
+
+        return_annotation = ''
+
+        # if return_type is not MISSING:
+        #     locals['__dataclass_return_type__'] = return_type
+        #     return_annotation = '->__dataclass_return_type__'
+        # args = ','.join(args)
+        # body = '\n'.join(f'  {b}' for b in body)
+
+        # Compute the text of the entire function.
+        # txt = f' def {name}({args}){return_annotation}:\n{body}'
+
+        # Build the function code for all functions
+        # Free variables in exec are resolved in the global namespace.
+        # The global namespace we have is user-provided, so we can't modify it for
+        # our purposes. So we put the things we need into locals and introduce a
+        # scope to allow the function we're creating to close over them.
+        local_vars = ', '.join(locals.keys())
+        all_func_code = '\n'.join(
+            f"def __create_fn__({local_vars}):\n def {name}({','.join(func['args'])}):\n{func['code']}\n return {name}"
+            for name, func in self.functions.items()
+        )
+
+        # Print the generated code for debugging
+        # logging.debug(f"Generated function code:\n{all_func_code}")
+        # print(f"Generated function code:\n{all_func_code}")
+
+        ns = {}
+        exec(all_func_code, globals, ns)
+
+        # Print namespace for debugging
+        # logging.debug(f"Namespace after function compilation: {self.namespace}")
+
+        return ns['__create_fn__'](**locals)
+
+        # txt = f"def __create_fn__({local_vars}):\n{txt}\n return {name}"
+        # ns = {}
+        # exec(txt, globals, ns)
+        # return ns['__create_fn__'](**locals)
+
+
+
+
+
+    def get_namespace(self):
+        """Return the namespace containing all compiled functions."""
+        return self.namespace

--- a/dataclass_wizard/utils/code_builder.py
+++ b/dataclass_wizard/utils/code_builder.py
@@ -34,6 +34,16 @@ class CodeBuilder:
 
         return self
 
+    def if_block(self, condition: str) -> 'CodeBuilder':
+        indent = '  ' * self.indent_level
+        self.current_function["body"].append(f"{indent}if {condition}:")
+        return self
+
+    def else_block(self) -> 'CodeBuilder':
+        indent = '  ' * self.indent_level
+        self.current_function["body"].append(f"{indent}else:")
+        return self
+
     def add_line(self, line: str):
         """Add a line to the current function's body with proper indentation."""
         indent = '  ' * self.indent_level

--- a/dataclass_wizard/utils/code_builder.py
+++ b/dataclass_wizard/utils/code_builder.py
@@ -1,10 +1,6 @@
-import types
-import logging
 from dataclasses import MISSING
-from timeit import timeit
 
-# Set up logging
-logging.basicConfig(level=logging.INFO, format='%(message)s')
+from dataclass_wizard.log import LOG
 
 
 class CodeBuilder:
@@ -66,9 +62,9 @@ class CodeBuilder:
         self.functions[self.current_function["name"]] = ({"args": self.current_function["args"], "code": func_code})
         self.current_function = None  # Reset current function
 
-    def compile_with_types(self, *, globals=None, locals=None,
-                           return_type=MISSING
-                           ):
+    def create_functions(self, *, globals=None, locals=None,
+                         return_type=MISSING
+                         ):
         """Create functions by compiling the code."""
         # Note that we may mutate locals. Callers beware!
         # The only callers are internal to this module, so no
@@ -100,7 +96,7 @@ class CodeBuilder:
 
         # Print the generated code for debugging
         # logging.debug(f"Generated function code:\n{all_func_code}")
-        # print(f"Generated function code:\n{all_func_code}")
+        LOG.debug(f"Generated function code:\n{all_func_code}")
 
         ns = {}
         exec(all_func_code, globals, ns)

--- a/dataclass_wizard/utils/code_builder.py
+++ b/dataclass_wizard/utils/code_builder.py
@@ -44,11 +44,11 @@ class CodeBuilder:
         self.current_function["body"].append(f"{indent}{line}")
 
     def add_lines(self, *lines: str):
-        """Add a line to the current function's body with proper indentation."""
+        """Add lines to the current function's body with proper indentation."""
         indent = '  ' * self.indent_level
-        add_to_fn_body = self.current_function["body"].append
-        for line in lines:
-            add_to_fn_body(f"{indent}{line}")
+        self.current_function["body"].extend(
+            [f"{indent}{line}" for line in lines]
+        )
 
     def increase_indent(self):
         """Increase indentation level for nested code."""

--- a/dataclass_wizard/wizard_mixins.py
+++ b/dataclass_wizard/wizard_mixins.py
@@ -131,8 +131,8 @@ class TOMLWizard:
         Converts a TOML `string` to an instance of the dataclass, or a list of
         the dataclass instances.
 
-        If `header` is passed in, and the value of this key in the parsed
-        ``dict`` object is a ``list``, then the return type is a ``List[T]``.
+        If ``header`` is provided and the corresponding value in the parsed
+        data is a ``list``, the return type is ``List[T]``.
         """
         if decoder is None:  # pragma: no cover
             decoder = toml.loads
@@ -149,11 +149,11 @@ class TOMLWizard:
                        header: str = 'items',
                        parse_float: ParseFloat = float) -> Union[T, List[T]]:
         """
-        Reads in the TOML file contents and converts to an instance of the
-        dataclass, or a list of the dataclass instances.
+        Reads the contents of a TOML file and converts them
+        into an instance (or list of instances) of the dataclass.
 
-        If `header` is passed in, and the value of this key in the parsed
-        ``dict`` object is a ``list``, then the return type is a ``List[T]``.
+        Similar to :meth:`from_toml`, it can return a list if ``header``
+        is specified and points to a list in the TOML data.
         """
         if decoder is None:  # pragma: no cover
             decoder = toml.load
@@ -171,7 +171,11 @@ class TOMLWizard:
                 multiline_strings: bool = False,
                 indent: int = 4) -> AnyStr:
         """
-        Converts the dataclass instance to a TOML `string` representation.
+        Converts a dataclass instance to a TOML `string`.
+
+        Optional parameters include ``multiline_strings``
+        for enabling/disabling multiline formatting of strings,
+        and ``indent`` for setting the indentation level.
         """
         if encoder is None:  # pragma: no cover
             encoder = toml_w.dumps
@@ -180,12 +184,14 @@ class TOMLWizard:
                        multiline_strings=multiline_strings,
                        indent=indent)
 
-    def to_toml_file(self: T, file: str, mode: str = 'w',
+    def to_toml_file(self: T, file: str, mode: str = 'wb',
                      encoder: Optional[FileEncoder] = None,
                      multiline_strings: bool = False,
                      indent: int = 4) -> None:
         """
-        Serializes the instance and writes it to a TOML file.
+        Serializes a dataclass instance and writes it to a TOML file.
+
+        By default, opens the file in "write binary" mode.
         """
         if encoder is None:  # pragma: no cover
             encoder = toml_w.dump
@@ -202,8 +208,8 @@ class TOMLWizard:
                      encoder: Optional[Encoder] = None,
                      **encoder_kwargs) -> AnyStr:
         """
-        Converts a ``list`` of dataclass instances to a TOML `string`
-        representation.
+        Serializes a ``list`` of dataclass instances into a TOML `string`,
+        grouped under a specified header.
         """
         if encoder is None:
             encoder = toml_w.dumps

--- a/docs/advanced_usage/serializer_hooks.rst
+++ b/docs/advanced_usage/serializer_hooks.rst
@@ -1,9 +1,10 @@
 Serializer Hooks
 ================
 
-    Note: To customize the load or dump process for annotated types
+.. note::
+    To customize the load or dump process for annotated types
     instead of individual fields, please see the `Type
-    Hooks <#type-hooks>`__ section.
+    Hooks <type_hooks.html>`__ section.
 
 You can optionally add hooks that are run before a JSON string or a
 Python ``dict`` object is loaded to a dataclass instance, or before the

--- a/docs/advanced_usage/serializer_hooks.rst
+++ b/docs/advanced_usage/serializer_hooks.rst
@@ -9,33 +9,52 @@ You can optionally add hooks that are run before a JSON string or a
 Python ``dict`` object is loaded to a dataclass instance, or before the
 dataclass instance is converted back to a Python ``dict`` object.
 
-To customize the load process, simply implement the ``__post_init__``
-method which will be run by the ``dataclass`` decorator.
+To customize the load process:
 
-To customize the dump process, simply extend from ``DumpMixin`` and
-override the ``__pre_as_dict__`` method which will be called whenever
-you invoke the ``to_dict`` or ``to_json`` methods. Please note that this
-will pass in the original dataclass instance, so updating any values
-will affect the fields of the underlying dataclass (**this might change
-in a future revision**).
+* To pre-process data before ``from_dict`` is called, simply
+  implement a ``_pre_from_dict`` method which will be called
+  whenever you invoke the ``from_dict`` or ``from_json`` methods.
+  Please note that this will pass in the original ``dict`` object,
+  so updating any values will affect data in the underlying ``dict``
+  (**this might change in a future revision**).
+* To post-process data, *after* a dataclass instance is de-serialized,
+  simply implement the ``__post_init__`` method which will be run
+  by the ``dataclass`` decorator.
+
+To customize the dump process, simply implement
+a ``__pre_as_dict__`` method which will be called
+whenever you invoke the ``to_dict`` or ``to_json``
+methods. Please note that this will pass in the
+original dataclass instance, so updating any values
+will affect the fields of the underlying dataclass
+(**this might change in a future revision**).
 
 A simple example to illustrate both approaches is shown below:
 
 .. code:: python3
 
     from dataclasses import dataclass
-    from dataclass_wizard import JSONSerializable, DumpMixin
+    from dataclass_wizard import JSONWizard
+    from dataclass_wizard.type_def import JSONObject
 
 
     @dataclass
-    class MyClass(JSONSerializable, DumpMixin):
+    class MyClass(JSONWizard):
         my_str: str
         my_int: int
+        my_bool: bool = False
 
         def __post_init__(self):
             self.my_str = self.my_str.title()
+            self.my_int *= 2
 
-        def __pre_as_dict__(self):
+        @classmethod
+        def _pre_from_dict(cls, o: JSONObject) -> JSONObject:
+            # o = o.copy()  # Copying the `dict` object is optional
+            o['my_bool'] = True  # Adds a new key/value pair
+            return o
+
+        def _pre_dict(self):
             self.my_str = self.my_str.swapcase()
 
 
@@ -44,9 +63,9 @@ A simple example to illustrate both approaches is shown below:
     c = MyClass.from_dict(data)
     print(repr(c))
     # prints:
-    #   MyClass(my_str='My String', my_int=10)
+    #   MyClass(my_str='My String', my_int=20, my_bool=True)
 
     string = c.to_json()
     print(string)
     # prints:
-    #   {"myStr": "mY sTRING", "myInt": 10}
+    #   {"myStr": "mY sTRING", "myInt": 20, "myBool": true}

--- a/docs/advanced_usage/serializer_hooks.rst
+++ b/docs/advanced_usage/serializer_hooks.rst
@@ -22,7 +22,7 @@ To customize the load process:
   by the ``dataclass`` decorator.
 
 To customize the dump process, simply implement
-a ``__pre_as_dict__`` method which will be called
+a ``_pre_dict`` method which will be called
 whenever you invoke the ``to_dict`` or ``to_json``
 methods. Please note that this will pass in the
 original dataclass instance, so updating any values

--- a/docs/advanced_usage/type_hooks.rst
+++ b/docs/advanced_usage/type_hooks.rst
@@ -1,6 +1,11 @@
 Type Hooks
 ==========
 
+.. note::
+    To customize the load or dump process for dataclass
+    fields instead of annotated types, please see the `Serializer
+    Hooks <serializer_hooks.html>`__ section.
+
 Sometimes you might want to customize the load and dump process for
 (annotated) variable types, rather than for specific dataclass fields.
 Type hooks are very useful and will let you do exactly that.

--- a/docs/common_use_cases/easier_debug_mode.rst
+++ b/docs/common_use_cases/easier_debug_mode.rst
@@ -1,0 +1,62 @@
+Easier Debug Mode
+=================
+
+While one way to see ``DEBUG`` level (or above) logs for this
+library is to enable the ``debug_enabled`` flag in ``JSONWizard.Meta``,
+this can sometimes be time-consuming, and still requires correct setup
+of the ``logging`` module::
+
+    import logging
+    from dataclasses import dataclass
+
+    from dataclass_wizard import JSONWizard
+
+
+    logging.basicConfig(level='DEBUG')
+
+
+    @dataclass
+    class MyClass(JSONWizard):
+
+        class _(JSONWizard.Meta):
+            debug_enabled = True
+
+An easier approach, is to pass in ``debug=True`` as shown below:
+
+
+.. code:: python3
+
+    from dataclasses import dataclass
+
+    from dataclass_wizard import JSONWizard
+
+
+    @dataclass
+    class MyClass(JSONWizard, debug=True):
+
+        class _(JSONWizard.Meta):
+            skip_defaults = True
+            key_transform_with_dump = 'PASCAL'
+
+        my_bool: bool
+        my_int: int = 2
+
+        @classmethod
+        def _pre_from_dict(cls, o):
+            o['myBool'] = True
+            return o
+
+
+    # because of `debug=True` you should now see DEBUG
+    # (and above) logs from this library, such as below.
+    #
+    # DEBUG:dataclass_wizard:Generated function code:
+    #  def cls_fromdict(o):
+    # DEBUG:dataclass_wizard:Generated function code:
+    #  def cls_asdict(o:T,dict_factory=dict,...):
+
+    c = MyClass.from_dict({'myBool': 'false'})
+    print(c)
+    # {
+    #   "MyBool": true
+    # }

--- a/docs/common_use_cases/skip_the_str.rst
+++ b/docs/common_use_cases/skip_the_str.rst
@@ -1,6 +1,10 @@
 Skip the :meth:`__str__`
 ========================
 
+.. note::
+    It is now easier to view ``DEBUG``-level log messages from this library! Check out
+    the `Easier Debug Mode <easier_debug_mode.html>`__ section.
+
 The ``JSONSerializable`` class implements a default
 ``__str__`` method if a sub-class doesn't already define
 this method. This method will format the dataclass

--- a/docs/common_use_cases/wizard_mixins.rst
+++ b/docs/common_use_cases/wizard_mixins.rst
@@ -191,3 +191,148 @@ A (mostly) complete example of using the :class:`YAMLWizard` is as follows:
     #   ...
 
 .. _PyYAML: https://pypi.org/project/PyYAML/
+
+:class:`TOMLWizard`
+~~~~~~~~~~~~~~~~~~~
+
+The TOML Wizard provides an easy, convenient interface for converting ``dataclass`` instances to/from `TOML`_. This mixin enables simple loading, saving, and flexible serialization of TOML data, including support for custom key casing transforms.
+
+.. note::
+   By default, *NO* key transform is used in the TOML dump process. This means that a `snake_case` field name in Python is saved as `snake_case` in TOML. However, this can be customized without subclassing from :class:`JSONWizard`, as below.
+
+       >>> @dataclass
+       >>> class MyClass(TOMLWizard, key_transform='CAMEL'):
+       >>>     ...
+
+Dependencies
+------------
+- For reading TOML, `TOMLWizard` uses `Tomli`_ for Python 3.9 and 3.10, and the built-in `tomllib`_ for Python 3.11+.
+- For writing TOML, `Tomli-W`_ is used across all Python versions.
+
+.. _TOML: https://toml.io/en/
+.. _Tomli: https://pypi.org/project/tomli/
+.. _Tomli-W: https://pypi.org/project/tomli-w/
+.. _tomllib: https://docs.python.org/3/library/tomllib.html
+
+Example
+-------
+
+A (mostly) complete example of using the :class:`TOMLWizard` is as follows:
+
+.. code:: python3
+
+    from dataclasses import dataclass, field
+    from dataclass_wizard import TOMLWizard
+
+
+    @dataclass
+    class InnerData:
+        my_float: float
+        my_list: list[str] = field(default_factory=list)
+
+
+    @dataclass
+    class MyData(TOMLWizard):
+        my_str: str
+        my_dict: dict[str, int] = field(default_factory=dict)
+        inner_data: InnerData = field(default_factory=lambda: InnerData(3.14, ["hello", "world"]))
+
+
+    # TOML input string with nested tables and lists
+    toml_string = """
+    my_str = 'example'
+    [my_dict]
+    key1 = 1
+    key2 = '2'
+
+    [inner_data]
+    my_float = 2.718
+    my_list = ['apple', 'banana', 'cherry']
+    """
+
+    # Load from TOML string
+    data = MyData.from_toml(toml_string)
+
+    # Sample output of `data` after loading from TOML:
+    #> my_str = 'example'
+    #> my_dict = {'key1': 1, 'key2': 2}
+    #> inner_data = InnerData(my_float=2.718, my_list=['apple', 'banana', 'cherry'])
+
+    # Save to TOML file
+    data.to_toml_file('data.toml')
+
+    # Now read it back from the TOML file
+    new_data = MyData.from_toml_file('data.toml')
+
+    # Assert we get back the same data
+    assert data == new_data, "Data read from TOML file does not match the original."
+
+    # Create a list of dataclass instances
+    data_list = [data, new_data, MyData("another_example", {"key3": 3}, InnerData(1.618, ["one", "two"]))]
+
+    # Serialize the list to a TOML string
+    toml_output = MyData.list_to_toml(data_list, header='testing')
+
+    print(toml_output)
+    # [[testing]]
+    # my_str = "example"
+    #
+    # [testing.my_dict]
+    # key1 = 1
+    # key2 = 2
+    #
+    # [testing.inner_data]
+    # my_float = 2.718
+    # my_list = [
+    #     "apple",
+    #     "banana",
+    #     "cherry",
+    # ]
+    # ...
+
+This approach provides a straightforward way to handle TOML data within Python dataclasses.
+
+Methods
+-------
+
+.. method:: from_toml(cls, string_or_stream, *, decoder=None, header='items', parse_float=float)
+
+   Parses a TOML `string` or stream and converts it into an instance (or list of instances) of the dataclass. If `header` is provided and the corresponding value in the parsed data is a list, the return type is `List[T]`.
+
+   **Example usage:**
+
+      >>> data_str = '''my_str = "test"\n[inner]\nmy_float = 1.2'''
+      >>> obj = MyClass.from_toml(data_str)
+
+.. method:: from_toml_file(cls, file, *, decoder=None, header='items', parse_float=float)
+
+   Reads the contents of a TOML file and converts them into an instance (or list of instances) of the dataclass. Similar to :meth:`from_toml`, it can return a list if `header` is specified and points to a list in the TOML data.
+
+   **Example usage:**
+
+      >>> obj = MyClass.from_toml_file('config.toml')
+
+.. method:: to_toml(self, /, *encoder_args, encoder=None, multiline_strings=False, indent=4)
+
+   Converts a dataclass instance to a TOML string. Optional parameters include `multiline_strings` for enabling/disabling multiline formatting of strings and `indent` for setting the indentation level.
+
+   **Example usage:**
+
+      >>> toml_str = obj.to_toml()
+
+.. method:: to_toml_file(self, file, mode='wb', encoder=None, multiline_strings=False, indent=4)
+
+   Serializes a dataclass instance and writes it to a TOML file. By default, opens the file in "write binary" mode.
+
+   **Example usage:**
+
+      >>> obj.to_toml_file('output.toml')
+
+.. method:: list_to_toml(cls, instances, header='items', encoder=None, **encoder_kwargs)
+
+   Serializes a list of dataclass instances into a TOML string, grouped under a specified `header`.
+
+   **Example usage:**
+
+      >>> obj_list = [MyClass(), MyClass(my_str="example")]
+      >>> toml_str = MyClass.list_to_toml(obj_list)

--- a/docs/common_use_cases/wizard_mixins.rst
+++ b/docs/common_use_cases/wizard_mixins.rst
@@ -195,6 +195,10 @@ A (mostly) complete example of using the :class:`YAMLWizard` is as follows:
 :class:`TOMLWizard`
 ~~~~~~~~~~~~~~~~~~~
 
+.. admonition:: **Added in v0.28.0**
+
+   The :class:`TOMLWizard` was introduced in version 0.28.0.
+
 The TOML Wizard provides an easy, convenient interface for converting ``dataclass`` instances to/from `TOML`_. This mixin enables simple loading, saving, and flexible serialization of TOML data, including support for custom key casing transforms.
 
 .. note::

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ watchdog[watchmedo]==6.0.0
 Sphinx==7.4.7; python_version == "3.9"
 Sphinx==8.1.3; python_version >= "3.10"
 twine==5.1.1
+dataclass-wizard[toml]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,10 @@ flake8>=3  # pyup: ignore
 tox==4.23.2
 # Extras
 pytimeparse==1.1.8
+# [toml] extra
+tomli>=2,<3; python_version=="3.9"
+tomli>=2,<3; python_version=="3.10"
+tomli-w>=1,<2
 # TODO I don't know if we need the below on CI
 coverage>=6.2
 pip>=21.3.1

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,9 @@ setup(
     tests_require=test_requirements,
     extras_require={
         'timedelta': ['pytimeparse>=1.1.7'],
-        'yaml': ['PyYAML>=5.3'],
+        'toml': ['tomli>=2,<3; python_version == "3.9" or python_version == "3.10"',
+                 'tomli-w>=1,<2'],
+        'yaml': ['PyYAML>=6,<7'],
         'dev': dev_requires + doc_requires + test_requirements,
     },
     zip_safe=False

--- a/setup.py
+++ b/setup.py
@@ -87,8 +87,11 @@ setup(
     tests_require=test_requirements,
     extras_require={
         'timedelta': ['pytimeparse>=1.1.7'],
-        'toml': ['tomli>=2,<3; python_version == "3.9" or python_version == "3.10"',
-                 'tomli-w>=1,<2'],
+        'toml': [
+            'tomli>=2,<3; python_version=="3.9"',
+            'tomli>=2,<3; python_version=="3.10"',
+            'tomli-w>=1,<2'
+        ],
         'yaml': ['PyYAML>=6,<7'],
         'dev': dev_requires + doc_requires + test_requirements,
     },

--- a/tests/unit/test_wizard_mixins.py
+++ b/tests/unit/test_wizard_mixins.py
@@ -216,7 +216,7 @@ my_list = ["hello, world!", "123"]
 
     obj.to_toml_file(filename)
 
-    mock_open_write.assert_called_once_with(filename, 'w')
+    mock_open_write.assert_called_once_with(filename, 'wb')
 
 
 def test_toml_wizard_list_to_toml():


### PR DESCRIPTION
## v0.28.0

### Added

* `TOMLWizard`
* New (pre-process) serializer hooks
  * `_pre_from_dict`
  * `_pre_dict`
* `debug` param to `JSONWizard.__init_subclass__`
* `*.pyi` stub files for better Type Hinting and Autocompletion in IDEs (ex. PyCharm)
  * `abstractions.pyi`
  * `serial_json.pyi`
* Utility class `FunctionBuilder` to help build and dynamically `exec` a function

### Changed
* Minor Optimization and QOL Change: Dynamically `exec` Dataclass Load and Dump Functions
* Minor performance boon: If class defines a `from_dict` method (equivalent to `fromdict`) and a `to_dict` method (equivalent to `asdict`), replace them with the dynamically generated load/dump functions.
* Deprecate pre-process hook `DumpMixin.__pre_as_dict__`
