### PR TITLE
v0.29.2 - Bugfixes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,9 +7,9 @@ History
 
 **Bugfixes**
 
-* Fixed issue with using `Meta.auto_assign_tags` and `Meta.raise_on_unknown_json_key` together.
-* Resolved problem when `CatchAll` field is specified with a default value, but serializing with `skip_defaults=False`.
-* Improved performance in `UnionParser`: ensured that `get_parser()` is only called once per type.
+* Fixed issue with using :attr:`Meta.auto_assign_tags` and :attr:`Meta.raise_on_unknown_json_key` together.
+* Resolved problem when :type:`CatchAll` field is specified with a default value, but serializing with :attr:`skip_defaults=False`.
+* Improved performance in :class:`UnionParser`: ensured that :func:`get_parser` is only called once per annotated type.
 * Added test case(s) to confirm intended behavior.
 
 0.29.1 (2024-11-23)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,16 @@
 History
 =======
 
+0.29.2 (2024-11-24)
+-------------------
+
+**Bugfixes**
+
+* Fixed issue with using `Meta.auto_assign_tags` and `Meta.raise_on_unknown_json_key` together.
+* Resolved problem when `CatchAll` field is specified with a default value, but serializing with `skip_defaults=False`.
+* Improved performance in `UnionParser`: ensured that `get_parser()` is only called once per type.
+* Added test case(s) to confirm intended behavior.
+
 0.29.1 (2024-11-23)
 -------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,10 +7,11 @@ History
 
 **Bugfixes**
 
-* Fixed issue with using :attr:`Meta.auto_assign_tags` and :attr:`Meta.raise_on_unknown_json_key` together.
-* Fix ``JSONWizard.debug`` so it does not overwrite existing class meta.
-* Resolved problem when :type:`CatchAll` field is specified with a default value, but serializing with :attr:`skip_defaults=False`.
-* Improved performance in :class:`UnionParser`: ensured that :func:`get_parser` is only called once per annotated type.
+* Fixed issue with using :attr:`Meta.auto_assign_tags` and :attr:`Meta.raise_on_unknown_json_key` together (:issue:`137`).
+* Fixed :attr:`JSONWizard.debug` to prevent overwriting existing class meta.
+* Resolved issue where both :attr:`auto_assign_tags` and :type:`CatchAll` resulted in the tag key being incorrectly saved in :type:`CatchAll`.
+* Fixed issue when :type:`CatchAll` field was specified with a default value but serialized with :attr:`skip_defaults=False`.
+* Improved performance in :class:`UnionParser`: ensured that :func:`get_parser` is called only once per annotated type.
 * Added test case(s) to confirm intended behavior.
 
 0.29.1 (2024-11-23)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ History
 **Bugfixes**
 
 * Fixed issue with using :attr:`Meta.auto_assign_tags` and :attr:`Meta.raise_on_unknown_json_key` together.
+* Fix ``JSONWizard.debug`` so it does not overwrite existing class meta.
 * Resolved problem when :type:`CatchAll` field is specified with a default value, but serializing with :attr:`skip_defaults=False`.
 * Improved performance in :class:`UnionParser`: ensured that :func:`get_parser` is only called once per annotated type.
 * Added test case(s) to confirm intended behavior.

--- a/dataclass_wizard/dumpers.py
+++ b/dataclass_wizard/dumpers.py
@@ -414,7 +414,10 @@ def dump_func_for_dataclass(cls: Type[T],
                             f'  paths{key_part} = asdict(o.{field},dict_factory,hooks,config,cls_to_asdict)')
 
                 elif has_catch_all and catch_all_field == field:
-                    field_assignments.append(f"if not {skip_field}:")
+                    if field in field_to_default:
+                        field_assignments.append(f"if o.{field} != {default_value} and not {skip_field}:")
+                    else:
+                        field_assignments.append(f"if not {skip_field}:")
                     field_assignments.append(f"  for k, v in o.{field}.items():")
                     field_assignments.append("    result.append((k,"
                                              "asdict(v,dict_factory,hooks,config,cls_to_asdict)))")

--- a/dataclass_wizard/loaders.py
+++ b/dataclass_wizard/loaders.py
@@ -640,6 +640,11 @@ def load_func_for_dataclass(
     catch_all_field = json_to_field.get(CATCH_ALL)
     has_catch_all = catch_all_field is not None
 
+    # Fix for using `auto_assign_tags` and `raise_on_unknown_json_key` together
+    # See https://github.com/rnag/dataclass-wizard/issues/137
+    if meta.tag is not None:
+        json_to_field[meta.tag_key] = ExplicitNull
+
     _locals = {
         'cls': cls,
         'py_case': cls_loader.transform_json_field,

--- a/dataclass_wizard/serial_json.py
+++ b/dataclass_wizard/serial_json.py
@@ -2,8 +2,9 @@ import json
 import logging
 
 from .abstractions import AbstractJSONWizard
+from .bases import AbstractMeta
 from .bases_meta import BaseJSONWizardMeta, LoadMeta
-from .class_helper import call_meta_initializer_if_needed
+from .class_helper import call_meta_initializer_if_needed, get_meta
 from .dumpers import asdict
 from .loaders import fromdict, fromlist
 # noinspection PyProtectedMember
@@ -69,7 +70,11 @@ class JSONSerializable(AbstractJSONWizard):
             # minimum logging level for logs by this library
             min_level = default_lvl if isinstance(debug, bool) else debug
             # set `debug_enabled` flag for the class's Meta
-            LoadMeta(debug_enabled=min_level).bind_to(cls)
+            cls_meta = get_meta(cls)
+            if cls_meta is not AbstractMeta:
+                cls_meta.debug_enabled = min_level
+            else:
+                LoadMeta(debug_enabled=min_level).bind_to(cls)
 
 
 def _str_fn():

--- a/dataclass_wizard/utils/function_builder.py
+++ b/dataclass_wizard/utils/function_builder.py
@@ -79,6 +79,22 @@ class FunctionBuilder:
         """
         return self._with_new_block('if', condition)
 
+    def elif_(self, condition: str) -> 'FunctionBuilder':
+        """Equivalent to the `elif` statement in Python.
+
+        Sample Usage:
+
+            >>> with FunctionBuilder().elif_('something is True'):
+            >>>     ...
+
+        Will generate the following code:
+
+            >>> elif something is True:
+            >>>     ...
+
+        """
+        return self._with_new_block('elif', condition)
+
     def else_(self) -> 'FunctionBuilder':
         """Equivalent to the `else` statement in Python.
 

--- a/tests/unit/test_load.py
+++ b/tests/unit/test_load.py
@@ -1903,6 +1903,68 @@ def test_catch_all_with_default():
 
     @dataclass
     class MyData(JSONWizard):
+        my_str: str
+        my_float: float
+        extra_data: CatchAll = False
+
+    # Case 1: Extra Data is provided
+
+    input_dict = {
+        'my_str': "test",
+        'my_float': 3.14,
+        'my_other_str': "test!",
+        'my_bool': True
+    }
+
+    # Load from TOML string
+    data = MyData.from_dict(input_dict)
+
+    assert data.extra_data == {'my_other_str': 'test!', 'my_bool': True}
+
+    # Save to TOML file
+    output_dict = data.to_dict()
+
+    assert output_dict == {
+        "myStr": "test",
+        "myFloat": 3.14,
+        "my_other_str": "test!",
+        "my_bool": True
+    }
+
+    new_data = MyData.from_dict(output_dict)
+
+    assert new_data.extra_data == {'my_other_str': 'test!', 'my_bool': True}
+
+    # Case 2: Extra Data is not provided
+
+    input_dict = {
+        'my_str': "test",
+        'my_float': 3.14,
+    }
+
+    # Load from TOML string
+    data = MyData.from_dict(input_dict)
+
+    assert data.extra_data is False
+
+    # Save to TOML file
+    output_dict = data.to_dict()
+
+    assert output_dict == {
+        "myStr": "test",
+        "myFloat": 3.14,
+    }
+
+    new_data = MyData.from_dict(output_dict)
+
+    assert new_data.extra_data is False
+
+
+def test_catch_all_with_skip_defaults():
+    """'Catch All' support with a default field value and `skip_defaults`."""
+
+    @dataclass
+    class MyData(JSONWizard):
         class _(JSONWizard.Meta):
             skip_defaults = True
 

--- a/tests/unit/test_load.py
+++ b/tests/unit/test_load.py
@@ -2252,33 +2252,43 @@ def test_auto_assign_tags_and_raise_on_unknown_json_key():
     assert c == Container.from_dict(output_dict)
 
 
-# def test_auto_assign_tags_and_catch_all():
-#
-#     @dataclass
-#     class A:
-#         mynumber: int
-#
-#     @dataclass
-#     class B:
-#         mystring: str
-#
-#     @dataclass
-#     class Container(JSONWizard, debug=True):
-#         obj2: Union[A, B]
-#         extra: CatchAll = None
-#
-#         class _(JSONWizard.Meta):
-#             auto_assign_tags = True
-#
-#     c = Container(obj2=B("bar"))
-#
-#     output_dict = c.to_dict()
-#
-#     assert output_dict == {
-#         "obj2": {
-#             "mystring": "bar",
-#             "__tag__": "B"
-#         }
-#     }
-#
-#     assert c == Container.from_dict(output_dict)
+def test_auto_assign_tags_and_catch_all():
+    """Using both `auto_assign_tags` and `CatchAll` does not save tag key in `CatchAll`."""
+    @dataclass
+    class A:
+        mynumber: int
+        extra: CatchAll = None
+
+    @dataclass
+    class B:
+        mystring: str
+        extra: CatchAll = None
+
+    @dataclass
+    class Container(JSONWizard, debug=False):
+        obj2: Union[A, B]
+        extra: CatchAll = None
+
+        class _(JSONWizard.Meta):
+            auto_assign_tags = True
+            tag_key = 'type'
+
+    c = Container(obj2=B("bar"))
+
+    output_dict = c.to_dict()
+
+    assert output_dict == {
+        "obj2": {
+            "mystring": "bar",
+            "type": "B"
+        }
+    }
+
+    c2 = Container.from_dict(output_dict)
+    assert c2 == c == Container(obj2=B(mystring='bar', extra=None), extra=None)
+
+    assert c2.to_dict() == {
+        "obj2": {
+            "mystring": "bar", "type": "B"
+        }
+    }

--- a/tests/unit/test_load.py
+++ b/tests/unit/test_load.py
@@ -2156,3 +2156,67 @@ def test_from_dict_with_nested_object_key_path_with_skip_defaults():
             }
         },
     }
+
+
+def test_auto_assign_tags_and_raise_on_unknown_json_key():
+
+    @dataclass
+    class A:
+        mynumber: int
+
+    @dataclass
+    class B:
+        mystring: str
+
+    @dataclass
+    class Container(JSONWizard):
+        obj2: Union[A, B]
+
+        class _(JSONWizard.Meta):
+            auto_assign_tags = True
+            raise_on_unknown_json_key = True
+
+    c = Container(obj2=B("bar"))
+
+    output_dict = c.to_dict()
+
+    assert output_dict == {
+        "obj2": {
+            "mystring": "bar",
+            "__tag__": "B"
+        }
+    }
+
+    assert c == Container.from_dict(output_dict)
+
+
+# def test_auto_assign_tags_and_catch_all():
+#
+#     @dataclass
+#     class A:
+#         mynumber: int
+#
+#     @dataclass
+#     class B:
+#         mystring: str
+#
+#     @dataclass
+#     class Container(JSONWizard, debug=True):
+#         obj2: Union[A, B]
+#         extra: CatchAll = None
+#
+#         class _(JSONWizard.Meta):
+#             auto_assign_tags = True
+#
+#     c = Container(obj2=B("bar"))
+#
+#     output_dict = c.to_dict()
+#
+#     assert output_dict == {
+#         "obj2": {
+#             "mystring": "bar",
+#             "__tag__": "B"
+#         }
+#     }
+#
+#     assert c == Container.from_dict(output_dict)


### PR DESCRIPTION
## Fixes
* Using `Meta.auto_assign_tags` and `Meta.raise_on_unknown_json_key` together
* When `CatchAll` field is specified with a default value, but serializing with `skip_defaults=False`
* Performance: In `UnionParser`, ensure that `get_parser()` is only called once per type
* Add test case(s) to confirm intended behavior

## Notes
* Closes #137 