### PR TITLE
v0.23: Fixed compatibility between Global Meta Settings and `recursive_classes`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,15 @@
 History
 =======
 
+0.29.3 (2024-11-24)
+-------------------
+
+**Bugfixes**
+
+* Fixed compatibility between `Global Meta Settings`_ and :attr:`recursive_classes` (:issue:`142`).
+
+.. _Global Meta Settings: https://dataclass-wizard.readthedocs.io/en/latest/common_use_cases/meta.html#global-meta-settings
+
 0.29.2 (2024-11-24)
 -------------------
 

--- a/dataclass_wizard/loaders.py
+++ b/dataclass_wizard/loaders.py
@@ -302,7 +302,7 @@ class LoadMixin(AbstractLoader, BaseLoadHook):
 
                         # enable support for cyclic / self-referential dataclasses
                         # see https://github.com/rnag/dataclass-wizard/issues/62
-                        if config and config.recursive_classes:
+                        if AbstractMeta.recursive_classes or (config and config.recursive_classes):
                             # noinspection PyTypeChecker
                             return RecursionSafeParser(
                                 base_cls, extras, base_type, hook=None


### PR DESCRIPTION
Closes #142 