### PR TITLE
add explicit utf-8 encoding for setup.py 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ else:   # Running on CI
 about = {}
 exec((here / package_name / '__version__.py').read_text(), about)
 
-readme = (here / 'README.rst').read_text()
-history = (here / 'HISTORY.rst').read_text()
+readme = (here / 'README.rst').read_text(encoding='utf-8')
+history = (here / 'HISTORY.rst').read_text(encoding='utf-8')
 
 setup(
     name=about['__title__'],


### PR DESCRIPTION
Due to unicode characters being present in README.rst and HISTORY.rst, `pip install .` from source does not work out of the box on windows. See:
```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 3829: character maps to <undefined>
```
Adding the explicit encoding fixes this.

