### PR TITLE
Fix `pip install -e .[dev]` on Python 3.9

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,12 @@ extensions = [
     'sphinx_copybutton',
 ]
 
+# The `sphinx_autodoc_typehints` extension requires Python 3.10;
+# see `docs/requirements.txt`.
+# Documentation without typing hints is better than no docs at all.
+if sys.version_info < (3, 10):
+    extensions.remove('sphinx_autodoc_typehints')
+
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
 }

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx-issues==5.0.0
-sphinx-autodoc-typehints==2.5.0
+sphinx-autodoc-typehints==2.5.0; python_version>="3.10"
 sphinx-copybutton==0.5.2
 typing-extensions>=4.9.0


### PR DESCRIPTION
The Sphinx extension `sphinx-autodoc-typehints` requires Python 3.10 or newer. This breaks `pip install -e .[dev]` when on Python 3.9.

It makes sense to keep supporting local Python 3.9 installs, because that’s the minimum Python version that dataclass_wizard supports.
Contributors may prefer installing that minimum Python version on their local dev environment, because it helps them avoid language elements and batteries that Python 3.9 doesn’t support.

This PR adds a condition to both `docs/requirements.txt` and `docs/conf.py` to unblock `pip install -e .[dev]`.

Note that CI never caught this issue, because `setup.py` conditionally ignores extra dependencies when on CI.
