### PR TITLE
Fix more type annotations

### DIFF
--- a/dataclass_wizard/environ/lookups.pyi
+++ b/dataclass_wizard/environ/lookups.pyi
@@ -1,13 +1,13 @@
 from dataclasses import MISSING
-from typing import ClassVar
+from typing import ClassVar, TypeAlias, Union
 
 from ..decorators import cached_class_property
 from ..type_def import StrCollection, EnvFileType
 
 
-type _MISSING_TYPE = type(MISSING)
-type STR_OR_MISSING = str | _MISSING_TYPE
-type STR_OR_NONE = str | None
+_MISSING_TYPE: TypeAlias = type(MISSING)
+STR_OR_MISSING: TypeAlias = Union[str, _MISSING_TYPE]
+STR_OR_NONE: TypeAlias = Union[str, None]
 
 # Type of `os.environ` or `DotEnv` dict
 Environ = dict[str, STR_OR_NONE]

--- a/dataclass_wizard/utils/object_path.pyi
+++ b/dataclass_wizard/utils/object_path.pyi
@@ -1,8 +1,8 @@
 from dataclasses import MISSING
-from typing import Any, Sequence
+from typing import Any, Sequence, TypeAlias, Union
 
-type PathPart = str | int | float | bool
-type PathType = Sequence[PathPart]
+PathPart: TypeAlias = Union[str, int, float, bool]
+PathType: TypeAlias = Sequence[PathPart]
 
 
 def safe_get(data: dict | list,


### PR DESCRIPTION
These are all using python 3.12 syntax that breaks support for older python versions in this library