### PR TITLE
Fix syntax error in typing stubs

### DIFF
--- a/dataclass_wizard/v1/models.pyi
+++ b/dataclass_wizard/v1/models.pyi
@@ -616,6 +616,7 @@ class Field(_Field):
                  path: PathType | None,
                  default, default_factory, init, repr, hash, compare,
                  metadata, kw_only, doc):
+        ...
 
     # In Python 3.10, dataclasses adds a new parameter to the :class:`Field`
     # constructor: `kw_only`


### PR DESCRIPTION
In this pull request we fix a syntax error in the typing stubs I encountered using mypy on a project that uses this project.

Split off from https://github.com/rnag/dataclass-wizard/pull/213, as this immediately impacts our CI runs for our project.