### PR TITLE
fix: package list at building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,13 @@ all = [
 ]
 
 [tool.setuptools]
-packages = ["dataclass_wizard"]
+packages = [
+    "dataclass_wizard",
+    "dataclass_wizard.environ",
+    "dataclass_wizard.utils",
+    "dataclass_wizard.v1",
+    "dataclass_wizard.wizard_cli"
+]
 include-package-data = true
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
v0.36.3~5 release miss `dataclass_wizard/utils/string_conv.py` and `dataclass_wizard/v1/*.py` ...