### PR TITLE
Fix Dict with Union key type parsing (referencing wrong loop variable) (#245)

### DIFF
--- a/dataclass_wizard/_loaders.py
+++ b/dataclass_wizard/_loaders.py
@@ -589,7 +589,7 @@ class LoadMixin(BaseLoadHook):
 
             possible_tp = eval_forward_ref_if_needed(possible_tp, actual_cls)
 
-            tp_new = TypeInfo(possible_tp, i=i)
+            tp_new = TypeInfo(possible_tp, i=i, prefix=tp.prefix)
             tp_new.in_optional = in_optional
 
             if possible_tp is NoneType:

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -3646,3 +3646,41 @@ def test_str_and_int_enum():
     t2 = Test.from_dict(t.to_dict())
     assert t2.str_e is MyStrEnum.B
     assert t2.int_e is MyIntEnum.Z
+
+
+def test_dict_with_union_key_of_int_and_literal():
+    """
+    Regression test for https://github.com/rnag/dataclass-wizard/issues/245
+
+    When a ``Dict`` has a ``Union`` key type (e.g. ``int | Literal["AAA"]``),
+    the generated union-loader for the *key* must reference the key variable
+    rather than the value variable. Previously the sub-type loaders emitted
+    references to ``v2`` while the enclosing key-loader parameter was ``k2``,
+    so every otherwise-valid key raised ``ParseError``.
+    """
+
+    @dataclass
+    class Test(JSONWizard):
+        error: Dict[Union[int, Literal["AAA"]], str]
+        successful: Union[int, Literal["AAA"]]
+
+    # int-coercible keys *and* the literal key should all parse.
+    t = Test.from_dict(
+        {'error': {'1': '1', '2': '2', '3': '3', 'AAA': '4'},
+         'successful': '1'}
+    )
+    assert t.error == {1: '1', 2: '2', 3: '3', 'AAA': '4'}
+    assert t.successful == 1
+
+    # The literal value is also accepted for the scalar union field.
+    t2 = Test.from_dict(
+        {'error': {'1': '1', 'AAA': '4'}, 'successful': 'AAA'}
+    )
+    assert t2.error == {1: '1', 'AAA': '4'}
+    assert t2.successful == 'AAA'
+
+    # A key that is neither an int nor the literal is still rejected.
+    with pytest.raises(ParseError):
+        Test.from_dict(
+            {'error': {'1': '1', 'BBB': '4'}, 'successful': '1'}
+        )


### PR DESCRIPTION
Fixes #245

## Root cause

When a `Dict` has a `Union` key type (e.g. `Dict[int | Literal["AAA"], str]`), the generated dict-comprehension parses each key with a union-loader function whose parameter is the **key** variable (`k2`). That function is produced by `load_to_union` in `dataclass_wizard/_loaders.py`.

`load_to_union` reads the incoming variable name correctly via `v = tp.v_for_def()` (which respects `tp.prefix`, here `'k'`), but when it built the `TypeInfo` for each Union member it did not propagate that prefix:

```python
tp_new = TypeInfo(possible_tp, i=i)   # prefix defaults to 'v'
```

`TypeInfo`'s default `prefix` is `'v'`, so the candidate sub-loaders (the `Literal` loader and the int-coercion branch) emitted references to `v2` instead of `k2`. The union function is defined as `def _load_..._union(k2):`, so referencing the undefined-in-scope `v2` made every branch raise, and the key handler always fell through to `raise ParseError('Object was not in any of Union types')` — even for perfectly valid keys.

## Reproduction

```python
from dataclass_wizard import DataclassWizard
from typing import Dict, Literal

class Test(DataclassWizard):
    error: Dict[int | Literal["123"], str]
    successful: int | Literal["123"]

Test.from_json('{"error": {"1": "1", "2": "2", "3": "3", "123": "4"}, "successful": "1"}')
```

**Before the fix** (all keys are valid, yet it raises):

```
dataclass_wizard.errors.ParseError: Failed to load field `error` in class `Test`. Expected a type (<class 'int'>, typing.Literal['123']), got str.
  phase: load
  value: '1'
  error: Object was not in any of Union types
  tag_key: __tag__
  json_object: {"error": {"1": "1", "2": "2", "3": "3", "123": "4"}, "successful": "1"}
```

**After the fix**:

```
Test(error={1: '1', 2: '2', 3: '3', '123': '4'}, successful=1)
```

## Fix

A single-line change in `load_to_union` to propagate the enclosing prefix to each Union member's `TypeInfo`:

```diff
-            tp_new = TypeInfo(possible_tp, i=i)
+            tp_new = TypeInfo(possible_tp, i=i, prefix=tp.prefix)
```

This mirrors what the reporter suggested. It is localized to the union-loader generation and only affects which variable name the candidate sub-loaders reference. For the common case (Union as a *value* / field, prefix `'v'`) the emitted code is unchanged, so existing behavior is preserved; it only corrects the Dict-key case (prefix `'k'`).

## Tests

Added a focused regression test `test_dict_with_union_key_of_int_and_literal` in `tests/unit/test_loaders.py` that:

- asserts int-coercible keys **and** the literal key parse correctly,
- asserts the literal value is accepted for the scalar union field,
- asserts a key that is neither an int nor the literal still raises `ParseError`.

The test **fails on the unmodified code** (the traceback shows `k2 = '1'` while the body references `v2`) and **passes with the fix**. The existing `tests/unit/` load/dump/union/model/e2e suites remain green (319 passed across the core modules with optional deps installed; the only failures seen locally were pre-existing and caused solely by unrelated optional dependencies not installed in my environment — `pytimeparse`, `tomli-w`, `python-dotenv`).

Disclosure: prepared with AI assistance; reviewed and verified locally.
