### PR TITLE
Fix CatchAll fields breaking on reuse across structural contexts

### DIFF
--- a/dataclass_wizard/_dumpers.py
+++ b/dataclass_wizard/_dumpers.py
@@ -931,7 +931,13 @@ def dump_func_for_dataclass(
     skip_defaults = True if meta.skip_defaults else False
     skip_if = True if field_to_skip_if or skip_if_condition else False
 
-    catch_all_name: str | None = field_to_alias.pop(CATCH_ALL, None)
+    # Note: use `.get()` rather than `.pop()` here -- `field_to_alias` is a
+    # direct reference to a dict cached per-class (not a copy), so popping
+    # from it would permanently strip the `CATCH_ALL` marker from the shared
+    # cache the first time this runs, breaking any later codegen pass for
+    # this same class in a different structural context (e.g. nested vs.
+    # top-level). See: reuse-across-contexts regression test.
+    catch_all_name: str | None = field_to_alias.get(CATCH_ALL)
     has_catch_all = catch_all_name is not None
 
     if has_catch_all:

--- a/dataclass_wizard/_loaders.py
+++ b/dataclass_wizard/_loaders.py
@@ -1240,7 +1240,13 @@ def load_func_for_dataclass(
 
     on_unknown_key = meta.on_unknown_key
 
-    catch_all_field: str | None = field_to_aliases.pop(CATCH_ALL, None)
+    # Note: use `.get()` rather than `.pop()` here -- `field_to_aliases` is a
+    # direct reference to a dict cached per-class (not a copy), so popping
+    # from it would permanently strip the `CATCH_ALL` marker from the shared
+    # cache the first time this runs, breaking any later codegen pass for
+    # this same class in a different structural context (e.g. nested vs.
+    # top-level). See: reuse-across-contexts regression test.
+    catch_all_field: str | None = field_to_aliases.get(CATCH_ALL)
     has_catch_all = catch_all_field is not None
 
     if has_catch_all:

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -2806,6 +2806,54 @@ def test_catch_all_with_auto_key_case():
     assert opt == Options(my_extras={}, the_email='x@y.com')
 
 
+def test_catch_all_reused_across_structural_contexts():
+    """
+    A `CatchAll`-bearing dataclass must load/dump correctly regardless of how
+    many different "structural contexts" it's used in across a process: as
+    the direct top-level target of `from_dict`/`to_dict`, and as a field
+    nested inside one or more different enclosing classes.
+
+    Regression test for a bug where `load_func_for_dataclass` /
+    `dump_func_for_dataclass` popped the `CATCH_ALL` marker off of the
+    per-class alias dict returned by
+    `resolve_dataclass_field_to_alias_for_load` /
+    `resolve_dataclass_field_to_alias_for_dump` -- since that dict is a
+    direct (not copied) reference to a cache shared across all codegen
+    passes for the class, the first pass would permanently strip the
+    marker, and any later codegen pass for the same class (e.g. nested
+    inside a different enclosing class) would then treat it as having no
+    `CatchAll` field at all, causing the field's `NewType` annotation to
+    reach `issubclass()` and raise `TypeError`.
+    """
+    @dataclass
+    class Leaf(JSONWizard):
+        name: str
+        extra_data: CatchAll = field(default_factory=dict)
+
+    @dataclass
+    class WrapperA(JSONWizard):
+        value: Leaf
+
+    @dataclass
+    class WrapperB(JSONWizard):
+        other: Leaf
+
+    # First use: direct top-level target.
+    leaf = Leaf.from_dict({'name': 'a', 'unrecognized': 'x'})
+    assert leaf == Leaf(name='a', extra_data={'unrecognized': 'x'})
+    assert leaf.to_dict() == {'name': 'a', 'unrecognized': 'x'}
+
+    # Second use: nested inside a first enclosing class.
+    wa = WrapperA.from_dict({'value': {'name': 'b', 'unrecognized': 'y'}})
+    assert wa == WrapperA(value=Leaf(name='b', extra_data={'unrecognized': 'y'}))
+    assert wa.to_dict() == {'value': {'name': 'b', 'unrecognized': 'y'}}
+
+    # Third use: nested inside a second, different enclosing class.
+    wb = WrapperB.from_dict({'other': {'name': 'c', 'unrecognized': 'z'}})
+    assert wb == WrapperB(other=Leaf(name='c', extra_data={'unrecognized': 'z'}))
+    assert wb.to_dict() == {'other': {'name': 'c', 'unrecognized': 'z'}}
+
+
 def test_from_dict_with_nested_object_alias_path():
     """
     Specifying a custom mapping of "nested" alias to dataclass field,


### PR DESCRIPTION
## Summary

A dataclass with a `CatchAll` field can currently only be successfully
loaded/dumped in **one distinct structural context per process**. "Context"
means: used as the direct top-level target of `.from_dict()`/`.to_dict()`,
vs. used as a field of enclosing class X, vs. used as a field of enclosing
class Y. Whichever context is hit first works; any second, differently-shaped
use of that same class then fails permanently for the rest of the process
with:

```
TypeError: issubclass() arg 1 must be a class
```

raised from `_loaders.py::load_dispatcher_for_annotation` (and the analogous
spot in `_dumpers.py`) at `if issubclass(origin, t):`.

This isn't recursion-specific — plain, non-self-referential classes hit it
too (e.g. calling `.from_dict()` directly on some class `Leaf` with a
`CatchAll` field, then later parsing a different class that has `Leaf` as a
nested field, breaks the second call). Self-referential classes
(`children: list[Self]`) are a special case that fails on their very *first*
use, since resolving them as a top-level target already requires generating
codegen for the same class twice in one pass (once as the entry point, once
as the nested self-reference).

## Repro

```python
from dataclasses import dataclass, field
from dataclass_wizard import JSONWizard
from dataclass_wizard.models import CatchAll

@dataclass
class Leaf(JSONWizard):
    name: str
    extra: CatchAll = field(default_factory=dict)

@dataclass
class Wrapper(JSONWizard):
    value: Leaf

Leaf.from_dict({"name": "a", "unrecognized": "x"})                # OK
Wrapper.from_dict({"value": {"name": "b", "unrecognized": "y"}})  # TypeError: issubclass() arg 1 must be a class
```

## Root cause

`load_func_for_dataclass()` (and `dump_func_for_dataclass()`) read the
per-class alias mapping via `resolve_dataclass_field_to_alias_for_load()` /
`_for_dump()`, which returns a **direct reference** to a dict cached once per
class in a module-level `WeakKeyDictionary` — not a copy. The code then did:

```python
catch_all_field: str | None = field_to_aliases.pop(CATCH_ALL, None)
```

`.pop()` destructively mutates that shared cached dict. The first time
codegen runs for a class, `has_catch_all` is correctly `True` and the
`CatchAll` field is stripped/special-cased as intended — but the marker is
now permanently gone from the shared cache. If codegen runs again for the
*same class* in a different structural context (which doesn't hit a
compiled-function cache, since nested-field codegen always calls
`load_func_for_dataclass`/`dump_func_for_dataclass` directly rather than
reusing `cls.__dataclass_wizard_from_dict__`), `has_catch_all` is now
incorrectly `False`. The field's declared type, `CatchAll = NewType('CatchAll', Mapping)`,
is a `typing.NewType` — callable, but not a class — so it falls through to
the normal dispatch path, which calls `issubclass(origin, t)` on it and
raises.

## Fix

Use `.get(CATCH_ALL)` instead of `.pop(CATCH_ALL, None)` in both
`_loaders.py` and `_dumpers.py`. `CATCH_ALL` is a sentinel string
(`'<-|CatchAll|->'`) that never collides with a real field name, so nothing
downstream relies on the entry being removed from the dict — only on
reading whether it's present. This makes the read side-effect-free, so the
shared per-class cache stays correct no matter how many different
structural contexts the class is later used in.

## Test plan

- [x] Added `test_catch_all_reused_across_structural_contexts` in
      `tests/unit/test_loaders.py`, covering a `CatchAll`-bearing class used
      as a top-level target, then nested in one enclosing class, then nested
      in a second, different enclosing class — all in the same process.
      Confirmed it reproduces the original `TypeError` against the
      unpatched source and passes with the fix.
- [x] Full existing suite passes: 885 passed, 2 skipped, 6 xfailed, 4 xpassed,
      0 failed.
